### PR TITLE
Make OIDC Session management optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -886,6 +886,7 @@ This table shows the extended attributes provided by the `Config` interface.
 |`requestTimeout` | Optional | `number`| 60000 (seconds) | Specifies in seconds how long a request to the web worker should wait before being timed out. |
 |`sessionRefreshInterval`|Optional|`number`| 300 (seconds)|Specifies how often the session state should be checked. To check the authentication state, the authorization endpoint is queried with the `prompt` parameter set to `none`.|
 |`checkSessionInterval` |Optional|`number`|3 (seconds)| Specifies how often the check-session iFrame should be queried to check the session state. This is used to perform single logout. |
+|`enableOIDCSessionManagement` |Optional|`boolean`| false | Flag to enable OIDC Session Management |
 
 #### The AuthClientConfig Interface
 

--- a/lib/src/client.ts
+++ b/lib/src/client.ts
@@ -44,6 +44,7 @@ import { SPAUtils } from "./utils";
  */
 const DefaultConfig: Partial<AuthClientConfig<Config>> = {
     checkSessionInterval: 3,
+    enableOIDCSessionManagement: false,
     sessionRefreshInterval: 300
 };
 

--- a/lib/src/clients/main-thread-client.ts
+++ b/lib/src/clients/main-thread-client.ts
@@ -322,7 +322,11 @@ export const MainThreadClient = async (
         if (await _authenticationClient.isAuthenticated()) {
             _spaHelper.clearRefreshTokenTimeout();
             _spaHelper.refreshAccessTokenAutomatically();
-            checkSession();
+
+            // Enable OIDC Sessions Management only if it is set to true in the config.
+            if (config.enableOIDCSessionManagement) {
+                checkSession();
+            }
 
             return Promise.resolve(await _authenticationClient.getBasicUserInfo());
         }
@@ -488,7 +492,11 @@ export const MainThreadClient = async (
 
                 _spaHelper.clearRefreshTokenTimeout();
                 _spaHelper.refreshAccessTokenAutomatically();
-                checkSession();
+
+                // Enable OIDC Sessions Management only if it is set to true in the config.
+                if (config.enableOIDCSessionManagement) {
+                    checkSession();
+                }
 
                 return _authenticationClient.getBasicUserInfo();
             })

--- a/lib/src/clients/web-worker-client.ts
+++ b/lib/src/clients/web-worker-client.ts
@@ -430,7 +430,11 @@ export const WebWorkerClient = (config: AuthClientConfig<WebWorkerClientConfig>)
                 return communicate<null, string>(message)
                     .then((url: string) => {
                         SPAUtils.setSignOutURL(url);
-                        checkSession();
+
+                        // Enable OIDC Sessions Management only if it is set to true in the config.
+                        if (config.enableOIDCSessionManagement) {
+                            checkSession();
+                        }
 
                         return Promise.resolve(response);
                     })
@@ -499,7 +503,11 @@ export const WebWorkerClient = (config: AuthClientConfig<WebWorkerClientConfig>)
 
         if (await isAuthenticated()) {
             await startAutoRefreshToken();
-            checkSession();
+
+            // Enable OIDC Sessions Management only if it is set to true in the config.
+            if (config.enableOIDCSessionManagement) {
+                checkSession();
+            }
 
             return getBasicUserInfo();
         }

--- a/lib/src/models/client-config.ts
+++ b/lib/src/models/client-config.ts
@@ -20,6 +20,12 @@ import { Storage } from "../constants";
 
 
 export interface SPAConfig {
+    /**
+     * Enable OIDC Session Management with PR Iframe.
+     * @remarks If the consumer app the OP is hosted in different domains,
+     * third party cookies has to be enabled for this to work properly.
+     */
+    enableOIDCSessionManagement?: boolean;
     checkSessionInterval?: number;
     sessionRefreshInterval?: number;
     resourceServerURLs?: string[];


### PR DESCRIPTION
## Purpose
OIDC session management uses an iFrame for polling. If the IDP is in a different domain to the consumer app and if third-party cookies are disabled, this will not work. Since cookies have to be sent in the prompt none request for the server to check for sessions.

If the third-part cookies are diabled or if the app is runnning on safari, this will cause a forever loop.

It's better to disable this feature by default.

## Goals
This PR disables enabling the OIDC session management by default. 

Fixes https://github.com/asgardeo/asgardeo-auth-spa-sdk/issues/46

## Approach
Add a new config `enableOIDCSessionManagement` is added so that users can enable this feature on demand.

## User stories
None

## Release note
None

## Documentation
Added to README

## Training
None

## Certification
None

## Marketing
None

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
None

## Related PRs
None

## Migrations (if applicable)
None

## Test environment
None
 
## Learning
None