### PR TITLE
Add null checking in session management helper and fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -982,7 +982,7 @@ Session information can be attached to the body of a custom-grant request using 
 This extends the `AxiosRequestConfig` by providing an additional attribute that is used to specify if the access token should be attached to the request or not.
 |Attribute | Type | Description|
 |--|--|--|
-|attachToken| `boolean`| Specifies if teh access token should be attached to the header of the request.|
+|attachToken| `boolean`| Specifies if the access token should be attached to the header of the request.|
 
 ## Develop
 

--- a/lib/package-lock.json
+++ b/lib/package-lock.json
@@ -5,9 +5,9 @@
 	"requires": true,
 	"dependencies": {
 		"@asgardeo/auth-js": {
-			"version": "0.2.9",
-			"resolved": "https://registry.npmjs.org/@asgardeo/auth-js/-/auth-js-0.2.9.tgz",
-			"integrity": "sha512-xGwUflJWZRuS+wQZn5/lysLGBmm9KeLF94sKbvSQsz2NIvDEQFnOKe39GSUW665d2BewQFURUcsvSxLZvmIaKQ==",
+			"version": "0.2.10",
+			"resolved": "https://registry.npmjs.org/@asgardeo/auth-js/-/auth-js-0.2.10.tgz",
+			"integrity": "sha512-dljGuveee4KZy2hcBBvBUPmpk8tb9p70HCzXwP1pM13OdujZT4mSU7VVWj3/4n+yryuVeDNGFsLgxnJr9fOTmQ==",
 			"requires": {
 				"base64url": "^3.0.1",
 				"fast-sha256": "^1.3.0",

--- a/lib/package.json
+++ b/lib/package.json
@@ -25,7 +25,7 @@
     "author": "Asgardeo",
     "license": "Apache-2.0",
     "dependencies": {
-        "@asgardeo/auth-js": "^0.2.9",
+        "@asgardeo/auth-js": "^0.2.10",
         "@babel/runtime-corejs3": "^7.11.2",
         "await-semaphore": "^0.1.3",
         "axios": "^0.21.0",

--- a/lib/src/client.ts
+++ b/lib/src/client.ts
@@ -28,6 +28,7 @@ import { Hooks, Storage } from "./constants";
 import { AsgardeoSPAException } from "./exception";
 import { HttpClientInstance } from "./http-client";
 import {
+    AuthSPAClientConfig,
     Config,
     HttpRequestConfig,
     HttpResponse,
@@ -183,7 +184,7 @@ export class AsgardeoSPAClient {
      *
      * @preserve
      */
-    public async initialize(config: AuthClientConfig<Config>): Promise<boolean> {
+    public async initialize(config: AuthSPAClientConfig): Promise<boolean> {
         this._storage = config.storage ?? Storage.SessionStorage;
         this._initialized = false;
         this._startedInitialize = true;
@@ -324,7 +325,7 @@ export class AsgardeoSPAClient {
      * auth.trySignInSilently()
      *```
      */
-    public async trySignInSilently(): Promise<BasicUserInfo | boolean | undefined>{
+    public async trySignInSilently(): Promise<BasicUserInfo | boolean | undefined> {
         await this._isInitialized();
         if (SPAUtils.wasSignInCalled()) {
             return;
@@ -372,7 +373,7 @@ export class AsgardeoSPAClient {
     public async signOut(): Promise<boolean> {
         await this._validateMethod();
 
-        const signOutResponse = await this._client?.signOut() ?? false;
+        const signOutResponse = (await this._client?.signOut()) ?? false;
 
         return signOutResponse;
     }

--- a/lib/src/clients/main-thread-client.ts
+++ b/lib/src/clients/main-thread-client.ts
@@ -555,28 +555,28 @@ export const MainThreadClient = async (
         }
 
         return new Promise((resolve, reject) => {
-            const listenToPrompNoneIFrame = async (e: MessageEvent) => {
+            const listenToPromptNoneIFrame = async (e: MessageEvent) => {
                 const data: Message<AuthorizationInfo | null> = e.data;
 
                 if (data?.type == CHECK_SESSION_SIGNED_OUT) {
-                    window.removeEventListener("message", listenToPrompNoneIFrame);
+                    window.removeEventListener("message", listenToPromptNoneIFrame);
                     resolve(false);
                 }
 
                 if (data?.type == CHECK_SESSION_SIGNED_IN && data?.data?.code) {
                     requestAccessToken(data.data.code, data?.data?.sessionState)
                         .then((response: BasicUserInfo) => {
-                            window.removeEventListener("message", listenToPrompNoneIFrame);
+                            window.removeEventListener("message", listenToPromptNoneIFrame);
                             resolve(response);
                         })
                         .catch((error) => {
-                            window.removeEventListener("message", listenToPrompNoneIFrame);
+                            window.removeEventListener("message", listenToPromptNoneIFrame);
                             reject(error);
                         });
                 }
             };
 
-            window.addEventListener("message", listenToPrompNoneIFrame);
+            window.addEventListener("message", listenToPromptNoneIFrame);
         });
     };
 

--- a/lib/src/clients/web-worker-client.ts
+++ b/lib/src/clients/web-worker-client.ts
@@ -380,27 +380,27 @@ export const WebWorkerClient = (config: AuthClientConfig<WebWorkerClientConfig>)
         }
 
         return new Promise((resolve, reject) => {
-            const listenToPrompNoneIFrame = async (e: MessageEvent) => {
+            const listenToPromptNoneIFrame = async (e: MessageEvent) => {
                 const data: Message<AuthorizationInfo | null> = e.data;
 
                 if (data?.type == CHECK_SESSION_SIGNED_OUT) {
-                    window.removeEventListener("message", listenToPrompNoneIFrame);
+                    window.removeEventListener("message", listenToPromptNoneIFrame);
                     resolve(false);
                 }
 
                 if (data?.type == CHECK_SESSION_SIGNED_IN && data?.data?.code) {
                     requestAccessToken(data?.data?.code, data?.data?.sessionState).then((response: BasicUserInfo) => {
-                        window.removeEventListener("message", listenToPrompNoneIFrame);
+                        window.removeEventListener("message", listenToPromptNoneIFrame);
                         resolve(response);
                     }).catch((error) => {
-                        window.removeEventListener("message", listenToPrompNoneIFrame);
+                        window.removeEventListener("message", listenToPromptNoneIFrame);
                         reject(error);
                     })
 
                 }
             };
 
-            window.addEventListener("message", listenToPrompNoneIFrame)
+            window.addEventListener("message", listenToPromptNoneIFrame)
         });
     };
 

--- a/lib/src/helpers/session-management-helper.ts
+++ b/lib/src/helpers/session-management-helper.ts
@@ -239,7 +239,7 @@ export const SessionManagementHelper = (() => {
         promptNoneIFrame.setAttribute("id", PROMPT_NONE_IFRAME);
         promptNoneIFrame.style.display = "none";
 
-        document.body.appendChild(rpIFrame);
+        document?.body?.appendChild(rpIFrame);
         rpIFrame = document.getElementById(RP_IFRAME) as HTMLIFrameElement;
         rpIFrame?.contentDocument?.body?.appendChild(opIFrame);
         rpIFrame?.contentDocument?.body?.appendChild(promptNoneIFrame);

--- a/lib/src/helpers/session-management-helper.ts
+++ b/lib/src/helpers/session-management-helper.ts
@@ -241,8 +241,8 @@ export const SessionManagementHelper = (() => {
 
         document.body.appendChild(rpIFrame);
         rpIFrame = document.getElementById(RP_IFRAME) as HTMLIFrameElement;
-        rpIFrame?.contentDocument?.body.appendChild(opIFrame);
-        rpIFrame?.contentDocument?.body.appendChild(promptNoneIFrame);
+        rpIFrame?.contentDocument?.body?.appendChild(opIFrame);
+        rpIFrame?.contentDocument?.body?.appendChild(promptNoneIFrame);
 
         _signOut = signOut;
 

--- a/lib/src/models/client-config.ts
+++ b/lib/src/models/client-config.ts
@@ -16,6 +16,7 @@
 * under the License.
 */
 
+import { AuthClientConfig } from "@asgardeo/auth-js";
 import { Storage } from "../constants";
 
 
@@ -38,3 +39,5 @@ export interface WebWorkerClientConfig  extends SPAConfig {
 }
 
 export type Config = MainThreadClientConfig | WebWorkerClientConfig;
+
+export type AuthSPAClientConfig = AuthClientConfig<Config>;

--- a/lib/src/worker/worker-core.ts
+++ b/lib/src/worker/worker-core.ts
@@ -67,10 +67,7 @@ export const WebWorkerCore = async (
         }
     };
 
-    _httpClient?.init && await _httpClient.init(
-        true,
-        attachToken
-    );
+    _httpClient?.init && (await _httpClient.init(true, attachToken));
 
     const setHttpRequestStartCallback = (callback: () => void): void => {
         _httpClient?.setHttpRequestStartCallback && _httpClient.setHttpRequestStartCallback(callback);
@@ -85,14 +82,17 @@ export const WebWorkerCore = async (
     };
 
     const setHttpRequestErrorCallback = (callback: (error: HttpError) => void): void => {
-        _httpClient?.setHttpRequestErrorCallback &&_httpClient.setHttpRequestErrorCallback(callback);
+        _httpClient?.setHttpRequestErrorCallback && _httpClient.setHttpRequestErrorCallback(callback);
     };
 
     const httpRequest = async (requestConfig: HttpRequestConfig): Promise<HttpResponse> => {
         let matches = false;
         const config = await _dataLayer.getConfigData();
 
-        for (const baseUrl of [...(await _dataLayer.getConfigData())?.resourceServerURLs ?? [], config?.serverOrigin]) {
+        for (const baseUrl of [
+            ...((await _dataLayer.getConfigData())?.resourceServerURLs ?? []),
+            config?.serverOrigin
+        ]) {
             if (requestConfig?.url?.startsWith(baseUrl)) {
                 matches = true;
 
@@ -158,8 +158,10 @@ export const WebWorkerCore = async (
         for (const requestConfig of requestConfigs) {
             let urlMatches = false;
 
-            for (const baseUrl of [ ...(await _dataLayer.getConfigData())?.resourceServerURLs ?? [],
-                config?.serverOrigin ]) {
+            for (const baseUrl of [
+                ...((await _dataLayer.getConfigData())?.resourceServerURLs ?? []),
+                config?.serverOrigin
+            ]) {
                 if (requestConfig.url?.startsWith(baseUrl)) {
                     urlMatches = true;
 
@@ -172,7 +174,6 @@ export const WebWorkerCore = async (
 
                 break;
             }
-
         }
 
         const requests: Promise<HttpResponse<any>>[] = [];
@@ -247,9 +248,12 @@ export const WebWorkerCore = async (
     };
 
     const getAuthorizationURL = async (params?: AuthorizationURLParams): Promise<AuthorizationResponse> => {
-        return _authenticationClient.getAuthorizationURL(params).then(async (url: string) => {
-            return { authorizationURL: url, pkce: (await _authenticationClient.getPKCECode()) as string };
-        });
+        return _authenticationClient
+            .getAuthorizationURL(params)
+            .then(async (url: string) => {
+                return { authorizationURL: url, pkce: (await _authenticationClient.getPKCECode()) as string };
+            })
+            .catch((error) => Promise.reject(error));
     };
 
     const startAutoRefreshToken = async (): Promise<void> => {
@@ -346,8 +350,8 @@ export const WebWorkerCore = async (
                     "requestCustomGrant",
                     "Request to the provided endpoint is prohibited.",
                     "Requests can only be sent to resource servers specified by the `resourceServerURLs`" +
-                    " attribute while initializing the SDK. The specified token endpoint in this request " +
-                    "cannot be found among the `resourceServerURLs`"
+                        " attribute while initializing the SDK. The specified token endpoint in this request " +
+                        "cannot be found among the `resourceServerURLs`"
                 )
             );
         }
@@ -387,7 +391,7 @@ export const WebWorkerCore = async (
 
     const getIDToken = async (): Promise<string> => {
         return _authenticationClient.getIDToken();
-    }
+    };
     const getOIDCServiceEndpoints = async (): Promise<OIDCEndpoints> => {
         return _authenticationClient.getOIDCServiceEndpoints();
     };


### PR DESCRIPTION
## Purpose
> This PR adds null checking to the iFrame creation logic in the session management helper.
> Also, this fixes typos in the readme file and in the codebase.
> This also returns an error when generating the authorization URL fails.
> In addition, this simplifies the argument type of the `initialize` method by introducing a new type called `AuthSPAClientConfig`.
