### PR TITLE
Add util to check of Auth params in the URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@
     -   [disableHttpHandler](#disableHttpHandler)
     -   [updateConfig](#updateConfig)
     -   [getHttpClient](#getHttpClient)
+-   [Utils](#utils)
 -   [Using the `form_post` Response Mode](#using-the-form_post-response-mode)
 -   [Storage](#storage)
 -   [Models](#Models)
@@ -843,6 +844,32 @@ This method returns the `HttpClientInstance`. This is the client that is used to
 
 ```TypeScript
 const httpClient = auth.getHttpClient();
+```
+
+## Utils
+
+### SPAUtils
+
+Collection of utils that could be used by consuming framework SDKs.
+
+#### hasAuthSearchParamsInURL
+
+```TypeScript
+SPAUtils.hasAuthSearchParamsInURL(): boolean
+```
+
+#### Returns
+
+An `boolean`
+
+#### Description
+
+Util function to test if `code` and `session_state` are available in the URL as search params.
+
+#### Example
+
+```TypeScript
+const hasParams: boolean = SPAUtils.hasAuthSearchParamsInURL();
 ```
 
 ## Using the `form_post` response mode

--- a/lib/src/public-api.ts
+++ b/lib/src/public-api.ts
@@ -22,6 +22,9 @@
 export * from "./client";
 export * from "./models";
 
+// Utils
+export * from "./utils/spa-utils"
+
 // Constants
 export * from "@asgardeo/auth-js";
 export * from "./constants/storage";

--- a/lib/src/utils/spa-utils.ts
+++ b/lib/src/utils/spa-utils.ts
@@ -117,4 +117,19 @@ export class SPAUtils {
 
         return state === SILENT_SIGN_IN_STATE || state === STATE;
     }
+
+    /**
+     * Util function to test if `code` and `session_state` are available in the URL as search params.
+     * @since 0.2.0
+     *
+     * @param params - Search params.
+     * @return {boolean}
+     */
+    public static hasAuthSearchParamsInURL(params: string = window.location.search): boolean {
+
+        const AUTH_CODE_REGEXP: RegExp = /[?&]code=[^&]+/;
+        const SESSION_STATE_REGEXP: RegExp = /[?&]session_state=[^&]+/;
+
+        return AUTH_CODE_REGEXP.test(params) && SESSION_STATE_REGEXP.test(params);
+   }
 }


### PR DESCRIPTION
## Purpose
A util function is needed so that the consuming SDKs could use it to test if the auth params are available in the URLs.

## Goals
Adds a util `hasAuthSearchParamsInURL` to addess $purpose

## Approach
```TypeScript
const hasParams: boolean = SPAUtils.hasAuthSearchParamsInURL();
```

## Related PRs
- Angular Auto Login - https://github.com/asgardeo/asgardeo-auth-angular-sdk/pull/96
- React Auto Login - https://github.com/asgardeo/asgardeo-auth-react-sdk/pull/44
