### PR TITLE
Fix page redirection bug and issues in the silent sign-in flow

### DIFF
--- a/lib/package-lock.json
+++ b/lib/package-lock.json
@@ -5,9 +5,9 @@
 	"requires": true,
 	"dependencies": {
 		"@asgardeo/auth-js": {
-			"version": "0.2.11",
-			"resolved": "https://registry.npmjs.org/@asgardeo/auth-js/-/auth-js-0.2.11.tgz",
-			"integrity": "sha512-67jQ9kDJGrKE2FVvpjOlkLsaFYzQUrlI+yBAXPQdVcM9EVnfEb3TXXq0QbY15XCA3kpVgvHFTi8jR4yVcFM1pg==",
+			"version": "0.2.12",
+			"resolved": "https://registry.npmjs.org/@asgardeo/auth-js/-/auth-js-0.2.12.tgz",
+			"integrity": "sha512-EPuiOprhfA/UGW6V4Kh7EL/VaILgXv+uH6OysOUog/xmngAuiougmOTVFQ5fcB5ypC79swab1AjcapRlp3U1+w==",
 			"requires": {
 				"base64url": "^3.0.1",
 				"fast-sha256": "^1.3.0",

--- a/lib/package.json
+++ b/lib/package.json
@@ -25,7 +25,7 @@
     "author": "Asgardeo",
     "license": "Apache-2.0",
     "dependencies": {
-        "@asgardeo/auth-js": "^0.2.11",
+        "@asgardeo/auth-js": "^0.2.12",
         "@babel/runtime-corejs3": "^7.11.2",
         "await-semaphore": "^0.1.3",
         "axios": "^0.21.0",

--- a/lib/src/client.ts
+++ b/lib/src/client.ts
@@ -328,6 +328,8 @@ export class AsgardeoSPAClient {
      */
     public async trySignInSilently(): Promise<BasicUserInfo | boolean | undefined> {
         await this._isInitialized();
+
+        // checks if the `signIn` method has been called and this method has not been called.
         if (SPAUtils.wasSignInCalled()) {
             return;
         }

--- a/lib/src/client.ts
+++ b/lib/src/client.ts
@@ -296,7 +296,7 @@ export class AsgardeoSPAClient {
         sessionState?: string
     ): Promise<BasicUserInfo | undefined> {
         await this._isInitialized();
-        if (!SPAUtils.setInitializedSignIn(Boolean(config?.callOnlyOnRedirect))) {
+        if (!SPAUtils.setInitializedSignIn(Boolean(config?.callOnlyOnRedirect)) && !SPAUtils.isStatePresentInURL()) {
             return;
         }
 
@@ -329,7 +329,7 @@ export class AsgardeoSPAClient {
     public async trySignInSilently(): Promise<BasicUserInfo | boolean | undefined> {
         await this._isInitialized();
 
-        // checks if the `signIn` method has been called and this method has not been called.
+        // checks if the `signIn` method was called before and this method was not called.
         if (SPAUtils.wasSignInCalled()) {
             return;
         }

--- a/lib/src/clients/main-thread-client.ts
+++ b/lib/src/clients/main-thread-client.ts
@@ -88,7 +88,7 @@ export const MainThreadClient = async (
         if (requestConfig.attachToken) {
             request.headers = {
                 ...request.headers,
-                Authorization: `Bearer ${await _authenticationClient.getAccessToken()}`
+                Authorization: `Bearer ${ await _authenticationClient.getAccessToken() }`
             };
         }
     };
@@ -115,7 +115,7 @@ export const MainThreadClient = async (
         let matches = false;
         const config = await _dataLayer.getConfigData();
 
-        for (const baseUrl of [...((await config?.resourceServerURLs) ?? []), config?.serverOrigin]) {
+        for (const baseUrl of [ ...((await config?.resourceServerURLs) ?? []), config?.serverOrigin ]) {
             if (requestConfig?.url?.startsWith(baseUrl)) {
                 matches = true;
 
@@ -167,8 +167,8 @@ export const MainThreadClient = async (
                     "httpRequest",
                     "Request to the provided endpoint is prohibited.",
                     "Requests can only be sent to resource servers specified by the `resourceServerURLs`" +
-                        " attribute while initializing the SDK. The specified endpoint in this request " +
-                        "cannot be found among the `resourceServerURLs`"
+                    " attribute while initializing the SDK. The specified endpoint in this request " +
+                    "cannot be found among the `resourceServerURLs`"
                 )
             );
         }
@@ -181,7 +181,7 @@ export const MainThreadClient = async (
         for (const requestConfig of requestConfigs) {
             let urlMatches = false;
 
-            for (const baseUrl of [...((await config)?.resourceServerURLs ?? []), config?.serverOrigin]) {
+            for (const baseUrl of [ ...((await config)?.resourceServerURLs ?? []), config?.serverOrigin ]) {
                 if (requestConfig.url?.startsWith(baseUrl)) {
                     urlMatches = true;
 
@@ -252,8 +252,8 @@ export const MainThreadClient = async (
                     "httpRequest",
                     "Request to the provided endpoint is prohibited.",
                     "Requests can only be sent to resource servers specified by the `resourceServerURLs`" +
-                        " attribute while initializing the SDK. The specified endpoint in this request " +
-                        "cannot be found among the `resourceServerURLs`"
+                    " attribute while initializing the SDK. The specified endpoint in this request " +
+                    "cannot be found among the `resourceServerURLs`"
                 )
             );
         }
@@ -444,8 +444,8 @@ export const MainThreadClient = async (
                     "requestCustomGrant",
                     "Request to the provided endpoint is prohibited.",
                     "Requests can only be sent to resource servers specified by the `resourceServerURLs`" +
-                        " attribute while initializing the SDK. The specified token endpoint in this request " +
-                        "cannot be found among the `resourceServerURLs`"
+                    " attribute while initializing the SDK. The specified token endpoint in this request " +
+                    "cannot be found among the `resourceServerURLs`"
                 )
             );
         }

--- a/lib/src/clients/main-thread-client.ts
+++ b/lib/src/clients/main-thread-client.ts
@@ -375,6 +375,8 @@ export const MainThreadClient = async (
 
             location.href = url;
 
+            await SPAUtils.waitTillPageRedirect();
+
             return Promise.resolve({
                 allowedScopes: "",
                 displayName: "",
@@ -394,6 +396,8 @@ export const MainThreadClient = async (
         }
 
         _spaHelper.clearRefreshTokenTimeout();
+
+        await SPAUtils.waitTillPageRedirect();
 
         return true;
     };

--- a/lib/src/clients/main-thread-client.ts
+++ b/lib/src/clients/main-thread-client.ts
@@ -88,7 +88,7 @@ export const MainThreadClient = async (
         if (requestConfig.attachToken) {
             request.headers = {
                 ...request.headers,
-                Authorization: `Bearer ${ await _authenticationClient.getAccessToken() }`
+                Authorization: `Bearer ${await _authenticationClient.getAccessToken()}`
             };
         }
     };
@@ -115,7 +115,7 @@ export const MainThreadClient = async (
         let matches = false;
         const config = await _dataLayer.getConfigData();
 
-        for (const baseUrl of [ ...((await config?.resourceServerURLs) ?? []), config?.serverOrigin ]) {
+        for (const baseUrl of [...((await config?.resourceServerURLs) ?? []), config?.serverOrigin]) {
             if (requestConfig?.url?.startsWith(baseUrl)) {
                 matches = true;
 
@@ -167,8 +167,8 @@ export const MainThreadClient = async (
                     "httpRequest",
                     "Request to the provided endpoint is prohibited.",
                     "Requests can only be sent to resource servers specified by the `resourceServerURLs`" +
-                    " attribute while initializing the SDK. The specified endpoint in this request " +
-                    "cannot be found among the `resourceServerURLs`"
+                        " attribute while initializing the SDK. The specified endpoint in this request " +
+                        "cannot be found among the `resourceServerURLs`"
                 )
             );
         }
@@ -181,7 +181,7 @@ export const MainThreadClient = async (
         for (const requestConfig of requestConfigs) {
             let urlMatches = false;
 
-            for (const baseUrl of [ ...((await config)?.resourceServerURLs ?? []), config?.serverOrigin ]) {
+            for (const baseUrl of [...((await config)?.resourceServerURLs ?? []), config?.serverOrigin]) {
                 if (requestConfig.url?.startsWith(baseUrl)) {
                     urlMatches = true;
 
@@ -252,8 +252,8 @@ export const MainThreadClient = async (
                     "httpRequest",
                     "Request to the provided endpoint is prohibited.",
                     "Requests can only be sent to resource servers specified by the `resourceServerURLs`" +
-                    " attribute while initializing the SDK. The specified endpoint in this request " +
-                    "cannot be found among the `resourceServerURLs`"
+                        " attribute while initializing the SDK. The specified endpoint in this request " +
+                        "cannot be found among the `resourceServerURLs`"
                 )
             );
         }
@@ -297,14 +297,14 @@ export const MainThreadClient = async (
     ): Promise<BasicUserInfo> => {
         const config = await _dataLayer.getConfigData();
 
-        const isLoggingOut = await _sessionManagementHelper.receivePromptNoneResponse(
+        const shouldStopContinue = await _sessionManagementHelper.receivePromptNoneResponse(
             async (sessionState: string | null) => {
                 await _dataLayer.setSessionDataParameter(SESSION_STATE, sessionState ?? "");
                 return;
             }
         );
 
-        if (isLoggingOut) {
+        if (shouldStopContinue) {
             return Promise.resolve({
                 allowedScopes: "",
                 displayName: "",
@@ -398,7 +398,7 @@ export const MainThreadClient = async (
         return true;
     };
 
-    const requestCustomGrant = async(config: CustomGrantConfig): Promise<BasicUserInfo | HttpResponse> => {
+    const requestCustomGrant = async (config: CustomGrantConfig): Promise<BasicUserInfo | HttpResponse> => {
         let useDefaultEndpoint = true;
         let matches = false;
         const clientConfig = await _dataLayer.getConfigData();

--- a/lib/src/clients/main-thread-client.ts
+++ b/lib/src/clients/main-thread-client.ts
@@ -565,9 +565,13 @@ export const MainThreadClient = async (
         return new Promise((resolve, reject) => {
             const listenToPromptNoneIFrame = async (e: MessageEvent) => {
                 const data: Message<AuthorizationInfo | null> = e.data;
+                const timer = setTimeout(() => {
+                    resolve(false);
+                }, 10000);
 
                 if (data?.type == CHECK_SESSION_SIGNED_OUT) {
                     window.removeEventListener("message", listenToPromptNoneIFrame);
+                    clearTimeout(timer);
                     resolve(false);
                 }
 
@@ -575,10 +579,12 @@ export const MainThreadClient = async (
                     requestAccessToken(data.data.code, data?.data?.sessionState)
                         .then((response: BasicUserInfo) => {
                             window.removeEventListener("message", listenToPromptNoneIFrame);
+                            clearTimeout(timer);
                             resolve(response);
                         })
                         .catch((error) => {
                             window.removeEventListener("message", listenToPromptNoneIFrame);
+                            clearTimeout(timer);
                             reject(error);
                         });
                 }

--- a/lib/src/clients/web-worker-client.ts
+++ b/lib/src/clients/web-worker-client.ts
@@ -413,7 +413,7 @@ export const WebWorkerClient = (config: AuthClientConfig<WebWorkerClientConfig>)
                 }
             };
 
-            window.addEventListener("message", listenToPromptNoneIFrame)
+            window.addEventListener("message", listenToPromptNoneIFrame);
         });
     };
 
@@ -474,13 +474,13 @@ export const WebWorkerClient = (config: AuthClientConfig<WebWorkerClientConfig>)
     ): Promise<BasicUserInfo> => {
         const config: AuthClientConfig<WebWorkerClientConfig> = await getConfigData();
 
-        const isLoggingOut = await _sessionManagementHelper.receivePromptNoneResponse(
+        const shouldStopContinue = await _sessionManagementHelper.receivePromptNoneResponse(
             async (sessionState: string | null) => {
                 return setSessionState(sessionState);
             }
         );
 
-        if (isLoggingOut) {
+        if (shouldStopContinue) {
             return Promise.resolve({
                 allowedScopes: "",
                 displayName: "",
@@ -641,14 +641,14 @@ export const WebWorkerClient = (config: AuthClientConfig<WebWorkerClientConfig>)
             type: GET_CONFIG_DATA
         };
 
-        return communicate< null, AuthClientConfig<WebWorkerClientConfig>>(message)
+        return communicate<null, AuthClientConfig<WebWorkerClientConfig>>(message)
             .then((response) => {
                 return Promise.resolve(response);
             })
             .catch((error) => {
                 return Promise.reject(error);
-        })
-    }
+            });
+    };
 
     const getBasicUserInfo = (): Promise<BasicUserInfo> => {
         const message: Message<null> = {
@@ -738,9 +738,8 @@ export const WebWorkerClient = (config: AuthClientConfig<WebWorkerClientConfig>)
         }
     };
 
-    const updateConfig = async(newConfig: Partial<AuthClientConfig<WebWorkerClientConfig>>): Promise<void> => {
-
-        const config = { ...await getConfigData(), ...newConfig };
+    const updateConfig = async (newConfig: Partial<AuthClientConfig<WebWorkerClientConfig>>): Promise<void> => {
+        const config = { ...(await getConfigData()), ...newConfig };
 
         const message: Message<Partial<AuthClientConfig<WebWorkerClientConfig>>> = {
             data: config,

--- a/lib/src/clients/web-worker-client.ts
+++ b/lib/src/clients/web-worker-client.ts
@@ -549,12 +549,14 @@ export const WebWorkerClient = (config: AuthClientConfig<WebWorkerClientConfig>)
         };
 
         return communicate<GetAuthURLConfig, AuthorizationResponse>(message)
-            .then((response) => {
+            .then(async (response) => {
                 if (response.pkce && config.enablePKCE) {
                     SPAUtils.setPKCE(response.pkce);
                 }
 
                 location.href = response.authorizationURL;
+
+                await SPAUtils.waitTillPageRedirect();
 
                 return Promise.resolve({
                     allowedScopes: "",
@@ -577,15 +579,17 @@ export const WebWorkerClient = (config: AuthClientConfig<WebWorkerClientConfig>)
      */
     const signOut = (): Promise<boolean> => {
         return isAuthenticated()
-            .then((response: boolean) => {
+            .then(async (response: boolean) => {
                 if (response) {
                     const message: Message<null> = {
                         type: SIGN_OUT
                     };
 
                     return communicate<null, string>(message)
-                        .then((response) => {
+                        .then(async (response) => {
                             window.location.href = response;
+
+                            await SPAUtils.waitTillPageRedirect();
 
                             return Promise.resolve(true);
                         })
@@ -594,6 +598,8 @@ export const WebWorkerClient = (config: AuthClientConfig<WebWorkerClientConfig>)
                         });
                 } else {
                     window.location.href = SPAUtils.getSignOutURL();
+
+                    await SPAUtils.waitTillPageRedirect();
 
                     return Promise.resolve(true);
                 }

--- a/lib/src/clients/web-worker-client.ts
+++ b/lib/src/clients/web-worker-client.ts
@@ -389,18 +389,24 @@ export const WebWorkerClient = (config: AuthClientConfig<WebWorkerClientConfig>)
         return new Promise((resolve, reject) => {
             const listenToPromptNoneIFrame = async (e: MessageEvent) => {
                 const data: Message<AuthorizationInfo | null> = e.data;
+                const timer = setTimeout(() => {
+                    resolve(false);
+                }, 10000);
 
                 if (data?.type == CHECK_SESSION_SIGNED_OUT) {
                     window.removeEventListener("message", listenToPromptNoneIFrame);
+                    clearTimeout(timer);
                     resolve(false);
                 }
 
                 if (data?.type == CHECK_SESSION_SIGNED_IN && data?.data?.code) {
                     requestAccessToken(data?.data?.code, data?.data?.sessionState).then((response: BasicUserInfo) => {
                         window.removeEventListener("message", listenToPromptNoneIFrame);
+                        clearTimeout(timer);
                         resolve(response);
                     }).catch((error) => {
                         window.removeEventListener("message", listenToPromptNoneIFrame);
+                        clearTimeout(timer);
                         reject(error);
                     })
 

--- a/lib/src/constants/session-management.ts
+++ b/lib/src/constants/session-management.ts
@@ -23,3 +23,4 @@ export const STATE = "Y2hlY2tTZXNzaW9u";
 export const SILENT_SIGN_IN_STATE = "sign-in-silently";
 export const INITIALIZED_SIGN_IN = "initialized-sign-in";
 export const INITIALIZED_SILENT_SIGN_IN = "initialized-silent-sign-in";
+export const PROMPT_NONE_REQUEST_SENT = "promptNoneRequestSent";

--- a/lib/src/helpers/session-management-helper.ts
+++ b/lib/src/helpers/session-management-helper.ts
@@ -202,7 +202,9 @@ export const SessionManagementHelper = (() => {
 
                 setSessionState && await setSessionState(newSessionState);
 
-                window.stop();
+                window.location.href = "about:blank";
+
+                return true;
             } else {
                 if (state === SILENT_SIGN_IN_STATE) {
                     const message: Message<null> = {

--- a/lib/src/helpers/session-management-helper.ts
+++ b/lib/src/helpers/session-management-helper.ts
@@ -135,7 +135,7 @@ export const SessionManagementHelper = (() => {
             if (e.data === "unchanged") {
                 // [RP] session state has not changed
             } else if (e.data === "error") {
-                window.top.location.href = await _signOut();
+                window.parent.location.href = await _signOut();
             } else {
                 // [RP] session state has changed. Sending prompt=none request...
                 sendPromptNoneRequest();
@@ -182,6 +182,7 @@ export const SessionManagementHelper = (() => {
     ): Promise<boolean> => {
         const state = new URL(window.location.href).searchParams.get("state");
         const sessionState = new URL(window.location.href).searchParams.get(SESSION_STATE);
+        const parent = window.parent.parent;
 
         if (state !== null && (state === STATE || state === SILENT_SIGN_IN_STATE)) {
             // Prompt none response.
@@ -198,10 +199,12 @@ export const SessionManagementHelper = (() => {
                     };
 
                     sessionStorage.setItem(INITIALIZED_SILENT_SIGN_IN, "false");
-                    window.top.postMessage(message, window.top.origin);
+                    parent.postMessage(message, parent.origin);
                     SPAUtils.setPromptNoneRequestSent(false);
 
                     window.location.href = "about:blank";
+
+                    await SPAUtils.waitTillPageRedirect();
 
                     return true;
                 }
@@ -213,6 +216,8 @@ export const SessionManagementHelper = (() => {
 
                 window.location.href = "about:blank";
 
+                await SPAUtils.waitTillPageRedirect();
+
                 return true;
             } else {
                 if (state === SILENT_SIGN_IN_STATE) {
@@ -221,18 +226,22 @@ export const SessionManagementHelper = (() => {
                     };
 
                     sessionStorage.setItem(INITIALIZED_SILENT_SIGN_IN, "false");
-                    window.top.postMessage(message, window.top.origin);
+                    window.parent.parent.postMessage(message, parent.origin);
                     SPAUtils.setPromptNoneRequestSent(false);
 
                     window.location.href = "about:blank";
+
+                    await SPAUtils.waitTillPageRedirect();
 
                     return true;
                 }
 
                 SPAUtils.setPromptNoneRequestSent(false);
 
-                window.top.location.href = await _signOut();
+                parent.location.href = await _signOut();
                 window.location.href = "about:blank";
+
+                await SPAUtils.waitTillPageRedirect();
 
                 return true;
             }

--- a/lib/src/utils/spa-utils.ts
+++ b/lib/src/utils/spa-utils.ts
@@ -122,6 +122,11 @@ export class SPAUtils {
         return false;
     }
 
+    /**
+     * Checks if the URL the user agent is redirected to after an authorization request has the state parameter.
+     *
+     * @returns {boolean} True if there is a session-check state or a silent sign-in state.
+     */
     public static isStatePresentInURL(): boolean {
         const state = new URL(window.location.href).searchParams.get("state");
 

--- a/lib/src/utils/spa-utils.ts
+++ b/lib/src/utils/spa-utils.ts
@@ -17,7 +17,13 @@
  */
 
 import { AsgardeoAuthClient, PKCE_CODE_VERIFIER, SIGN_OUT_URL } from "@asgardeo/auth-js";
-import { INITIALIZED_SIGN_IN, INITIALIZED_SILENT_SIGN_IN, PROMPT_NONE_REQUEST_SENT, SILENT_SIGN_IN_STATE, STATE } from "../constants";
+import {
+    INITIALIZED_SIGN_IN,
+    INITIALIZED_SILENT_SIGN_IN,
+    PROMPT_NONE_REQUEST_SENT,
+    SILENT_SIGN_IN_STATE,
+    STATE
+} from "../constants";
 
 export class SPAUtils {
     // eslint-disable-next-line @typescript-eslint/no-empty-function
@@ -141,7 +147,6 @@ export class SPAUtils {
      * @return {boolean}
      */
     public static hasAuthSearchParamsInURL(params: string = window.location.search): boolean {
-
         const AUTH_CODE_REGEXP: RegExp = /[?&]code=[^&]+/;
         const SESSION_STATE_REGEXP: RegExp = /[?&]session_state=[^&]+/;
 
@@ -150,6 +155,8 @@ export class SPAUtils {
 
     /**
      * Checks if a prompt none can be sent by checking if a request has already been sent.
+     *
+     * @since 0.2.3
      *
      * @returns {boolean} - True if a prompt none request has not been sent.
      */
@@ -163,9 +170,22 @@ export class SPAUtils {
     /**
      * Sets the status of prompt none request.
      *
+     * @since 0.2.3
+     *
      * @param canSend {boolean} - True if a prompt none request can be sent.
      */
     public static setPromptNoneRequestSent(canSend: boolean): void {
         sessionStorage.setItem(PROMPT_NONE_REQUEST_SENT, JSON.stringify(canSend));
+    }
+
+    /**
+     * Waits for a specified amount of time to give the user agent enough time to redirect.
+     *
+     * @param time {number} - Time in seconds.
+     */
+    public static async waitTillPageRedirect(time?: number): Promise<void> {
+        const timeToWait = time ?? 3000;
+
+        await new Promise((resolve) => setTimeout(resolve, timeToWait*1000));
     }
 }

--- a/lib/src/utils/spa-utils.ts
+++ b/lib/src/utils/spa-utils.ts
@@ -17,7 +17,7 @@
  */
 
 import { AsgardeoAuthClient, PKCE_CODE_VERIFIER, SIGN_OUT_URL } from "@asgardeo/auth-js";
-import { INITIALIZED_SIGN_IN, INITIALIZED_SILENT_SIGN_IN, SILENT_SIGN_IN_STATE, STATE } from "../constants";
+import { INITIALIZED_SIGN_IN, INITIALIZED_SILENT_SIGN_IN, PROMPT_NONE_REQUEST_SENT, SILENT_SIGN_IN_STATE, STATE } from "../constants";
 
 export class SPAUtils {
     // eslint-disable-next-line @typescript-eslint/no-empty-function
@@ -146,5 +146,26 @@ export class SPAUtils {
         const SESSION_STATE_REGEXP: RegExp = /[?&]session_state=[^&]+/;
 
         return AUTH_CODE_REGEXP.test(params) && SESSION_STATE_REGEXP.test(params);
-   }
+    }
+
+    /**
+     * Checks if a prompt none can be sent by checking if a request has already been sent.
+     *
+     * @returns {boolean} - True if a prompt none request has not been sent.
+     */
+    public static canSendPromptNoneRequest(): boolean {
+        const promptNoneRequestSentRaw = sessionStorage.getItem(PROMPT_NONE_REQUEST_SENT);
+        const promptNoneRequestSent = promptNoneRequestSentRaw ? JSON.parse(promptNoneRequestSentRaw) : null;
+
+        return !promptNoneRequestSent;
+    }
+
+    /**
+     * Sets the status of prompt none request.
+     *
+     * @param canSend {boolean} - True if a prompt none request can be sent.
+     */
+    public static setPromptNoneRequestSent(canSend: boolean): void {
+        sessionStorage.setItem(PROMPT_NONE_REQUEST_SENT, JSON.stringify(canSend));
+    }
 }

--- a/lib/src/utils/spa-utils.ts
+++ b/lib/src/utils/spa-utils.ts
@@ -69,6 +69,11 @@ export class SPAUtils {
         }
     }
 
+    /**
+     * Specifies if `trySilentSignIn` has been called.
+     *
+     * @returns {boolean} True if the `trySilentSignIn` method has been called once.
+     */
     public static setIsInitializedSilentSignIn(): boolean {
         const sessionIsInitialized = sessionStorage.getItem(INITIALIZED_SILENT_SIGN_IN);
         const isInitialized = sessionIsInitialized ? JSON.parse(sessionIsInitialized) : null;
@@ -84,6 +89,11 @@ export class SPAUtils {
         }
     }
 
+    /**
+     * Specifies if the `signIn` method has been called.
+     *
+     * @returns {boolean} True if the `signIn` has been called once and `trySilentSignIn` has not been called.
+     */
     public static wasSignInCalled(): boolean {
         const sessionIsInitialized = sessionStorage.getItem(INITIALIZED_SIGN_IN);
         const isInitialized = sessionIsInitialized ? JSON.parse(sessionIsInitialized) : null;

--- a/lib/src/utils/spa-utils.ts
+++ b/lib/src/utils/spa-utils.ts
@@ -186,6 +186,6 @@ export class SPAUtils {
     public static async waitTillPageRedirect(time?: number): Promise<void> {
         const timeToWait = time ?? 3000;
 
-        await new Promise((resolve) => setTimeout(resolve, timeToWait*1000));
+        await new Promise((resolve) => setTimeout(resolve, timeToWait * 1000));
     }
 }


### PR DESCRIPTION
## Purpose
>  This PR addresses the following issues:
- Resolves issues when using the `trySignInSilently` flow.
- Resolves the issue of code getting executed even after a page redirection is triggered using `location.href =` statement. 
- Sets a timeout to expire a `trySignInSilently` request.