### PR TITLE
Force trySignInSilently to use `query` as the `response_mode`

### DIFF
--- a/lib/src/clients/main-thread-client.ts
+++ b/lib/src/clients/main-thread-client.ts
@@ -297,7 +297,7 @@ export const MainThreadClient = async (
     ): Promise<BasicUserInfo> => {
         const config = await _dataLayer.getConfigData();
 
-        const shouldStopContinue = await _sessionManagementHelper.receivePromptNoneResponse(
+        const shouldStopContinue: boolean = await _sessionManagementHelper.receivePromptNoneResponse(
             async (sessionState: string | null) => {
                 await _dataLayer.setSessionDataParameter(SESSION_STATE, sessionState ?? "");
                 return;
@@ -583,13 +583,14 @@ export const MainThreadClient = async (
                     requestAccessToken(data.data.code, data?.data?.sessionState)
                         .then((response: BasicUserInfo) => {
                             window.removeEventListener("message", listenToPromptNoneIFrame);
-                            clearTimeout(timer);
                             resolve(response);
                         })
                         .catch((error) => {
                             window.removeEventListener("message", listenToPromptNoneIFrame);
-                            clearTimeout(timer);
                             reject(error);
+                        })
+                        .finally(() => {
+                            clearTimeout(timer);
                         });
                 }
             };

--- a/lib/src/clients/main-thread-client.ts
+++ b/lib/src/clients/main-thread-client.ts
@@ -552,10 +552,15 @@ export const MainThreadClient = async (
         ) as HTMLIFrameElement;
 
         try {
-            const url: string = await _authenticationClient.getAuthorizationURL({
+            const urlString: string = await _authenticationClient.getAuthorizationURL({
                 prompt: "none",
                 state: SILENT_SIGN_IN_STATE
             });
+
+            // Replace form_post with query
+            const urlObject = new URL(urlString);
+            urlObject.searchParams.set("response_mode", "query");
+            const url: string = urlObject.toString();
 
             if (config.storage === Storage.BrowserMemory && config.enablePKCE) {
                 SPAUtils.setPKCE((await _authenticationClient.getPKCECode()) as string);

--- a/lib/src/clients/web-worker-client.ts
+++ b/lib/src/clients/web-worker-client.ts
@@ -379,9 +379,16 @@ export const WebWorkerClient = (config: AuthClientConfig<WebWorkerClientConfig>)
         try {
             const response: AuthorizationResponse = await communicate<GetAuthURLConfig, AuthorizationResponse>(message);
 
-            (response.pkce && config.enablePKCE) && SPAUtils.setPKCE(response.pkce);
+            response.pkce && config.enablePKCE && SPAUtils.setPKCE(response.pkce);
 
-            promptNoneIFrame.src = response.authorizationURL;
+            const urlString: string = response.authorizationURL;
+
+            // Replace form_post with query
+            const urlObject = new URL(urlString);
+            urlObject.searchParams.set("response_mode", "query");
+            const url: string = urlObject.toString();
+
+            promptNoneIFrame.src = url;
         } catch (error) {
             return Promise.reject(error);
         }

--- a/lib/src/clients/web-worker-client.ts
+++ b/lib/src/clients/web-worker-client.ts
@@ -402,13 +402,13 @@ export const WebWorkerClient = (config: AuthClientConfig<WebWorkerClientConfig>)
                 if (data?.type == CHECK_SESSION_SIGNED_IN && data?.data?.code) {
                     requestAccessToken(data?.data?.code, data?.data?.sessionState).then((response: BasicUserInfo) => {
                         window.removeEventListener("message", listenToPromptNoneIFrame);
-                        clearTimeout(timer);
                         resolve(response);
                     }).catch((error) => {
                         window.removeEventListener("message", listenToPromptNoneIFrame);
-                        clearTimeout(timer);
                         reject(error);
-                    })
+                    }).finally((() => {
+                        clearTimeout(timer);
+                    }));
 
                 }
             };
@@ -474,7 +474,7 @@ export const WebWorkerClient = (config: AuthClientConfig<WebWorkerClientConfig>)
     ): Promise<BasicUserInfo> => {
         const config: AuthClientConfig<WebWorkerClientConfig> = await getConfigData();
 
-        const shouldStopContinue = await _sessionManagementHelper.receivePromptNoneResponse(
+        const shouldStopContinue: boolean = await _sessionManagementHelper.receivePromptNoneResponse(
             async (sessionState: string | null) => {
                 return setSessionState(sessionState);
             }


### PR DESCRIPTION
## Purpose
> The `trySignInSilently` method picked the response mode from the config object. This resulted in errors when the response mode is set to `from_post`. In order to fix this, this method now uses `query` as the response mode irrespective of the config object.
