### PR TITLE
Fix ID token empty issue in html-js and react-js apps

### DIFF
--- a/samples/asgardeo-html-js-app/app.js
+++ b/samples/asgardeo-html-js-app/app.js
@@ -91,16 +91,20 @@ function parseIdToken(idToken) {
     }
 
     const groups = [];
-    idTokenObject[ "decoded" ][ 1 ] && idTokenObject[ "decoded" ][ 1 ]?.groups?.forEach((group) => {
-        const groupArrays = group.split("/");
+    idTokenObject[ "decoded" ][ 1 ] && typeof idTokenObject[ "decoded" ][ 1 ]?.groups === "string" &&
+        groups.push(idTokenObject[ "decoded" ][ 1 ]?.groups);
 
-        if (groupArrays.length >= 2) {
-            groupArrays.shift();
-            groups.push(groupArrays.join("/"));
-        } else {
-            groups.push(group);
-        }
-    });
+    idTokenObject[ "decoded" ][ 1 ] && typeof idTokenObject[ "decoded" ][ 1 ]?.groups !== "string" &&
+        idTokenObject[ "decoded" ][ 1 ]?.groups?.forEach((group) => {
+            const groupArrays = group.split("/");
+
+            if (groupArrays.length >= 2) {
+                groupArrays.shift();
+                groups.push(groupArrays.join("/"));
+            } else {
+                groups.push(group);
+            }
+        });
 
     if (idTokenObject[ "decoded" ][ 1 ]?.groups) {
         idTokenObject[ "decoded" ][ 1 ].groups = groups;

--- a/samples/asgardeo-react-js-app/src/app.js
+++ b/samples/asgardeo-react-js-app/src/app.js
@@ -65,16 +65,20 @@ const App = () => {
         }
 
         const groups = [];
-        idTokenObject[ "decoded" ][ 1 ] && idTokenObject[ "decoded" ][ 1 ]?.groups?.forEach((group) => {
-            const groupArrays = group.split("/");
+        idTokenObject[ "decoded" ][ 1 ] && typeof idTokenObject[ "decoded" ][ 1 ]?.groups === "string" &&
+            groups.push(idTokenObject[ "decoded" ][ 1 ]?.groups);
 
-            if (groupArrays.length >= 2) {
-                groupArrays.shift();
-                groups.push(groupArrays.join("/"));
-            } else {
-                groups.push(group);
-            }
-        });
+        idTokenObject[ "decoded" ][ 1 ] && typeof idTokenObject[ "decoded" ][ 1 ]?.groups !== "string" &&
+            idTokenObject[ "decoded" ][ 1 ]?.groups?.forEach((group) => {
+                const groupArrays = group.split("/");
+
+                if (groupArrays.length >= 2) {
+                    groupArrays.shift();
+                    groups.push(groupArrays.join("/"));
+                } else {
+                    groups.push(group);
+                }
+            });
 
         if (idTokenObject[ "decoded" ][ 1 ]?.groups) {
             idTokenObject[ "decoded" ][ 1 ].groups = groups;


### PR DESCRIPTION
## Purpose
ID token becomes empty when groups attribute is added as a mandatory attribute and only one group is there. This PR fixes that issue.