### PR TITLE
Fix check session bugs

### DIFF
--- a/lib/src/client.ts
+++ b/lib/src/client.ts
@@ -46,7 +46,8 @@ import { SPAUtils } from "./utils";
 const DefaultConfig: Partial<AuthClientConfig<Config>> = {
     checkSessionInterval: 3,
     enableOIDCSessionManagement: false,
-    sessionRefreshInterval: 300
+    sessionRefreshInterval: 300,
+    storage: Storage.SessionStorage
 };
 
 const PRIMARY_INSTANCE = "primaryInstance";

--- a/lib/src/clients/main-thread-client.ts
+++ b/lib/src/clients/main-thread-client.ts
@@ -282,11 +282,13 @@ export const MainThreadClient = async (
         _sessionManagementHelper.initialize(
             config.clientID,
             oidcEndpoints.checkSessionIframe ?? "",
-            (await _authenticationClient.getBasicUserInfo()).sessionState,
+            async () => (await _authenticationClient.getBasicUserInfo()).sessionState,
             config.checkSessionInterval ?? 3,
             config.sessionRefreshInterval ?? 300,
             config.signInRedirectURL,
-            oidcEndpoints.authorizationEndpoint ?? ""
+            oidcEndpoints.authorizationEndpoint ?? "",
+            config.storage,
+            (sessionState: string) => _dataLayer.setSessionDataParameter(SESSION_STATE, sessionState ?? "")
         );
     };
 

--- a/lib/src/clients/main-thread-client.ts
+++ b/lib/src/clients/main-thread-client.ts
@@ -290,7 +290,8 @@ export const MainThreadClient = async (
             config.checkSessionInterval ?? 3,
             config.sessionRefreshInterval ?? 300,
             config.signInRedirectURL,
-            oidcEndpoints.authorizationEndpoint ?? ""
+            oidcEndpoints.authorizationEndpoint ?? "",
+            config.enablePKCE
         );
     };
 

--- a/lib/src/clients/main-thread-client.ts
+++ b/lib/src/clients/main-thread-client.ts
@@ -77,9 +77,13 @@ export const MainThreadClient = async (
 
     const _spaHelper = new SPAHelper<MainThreadClientConfig>(_authenticationClient);
     const _dataLayer = _authenticationClient.getDataLayer();
-    const _sessionManagementHelper = SessionManagementHelper(async () => {
-        return _authenticationClient.signOut();
-    });
+    const _sessionManagementHelper = SessionManagementHelper(
+        async () => {
+            return _authenticationClient.signOut();
+        },
+        config.storage ?? Storage.SessionStorage,
+        (sessionState: string) => _dataLayer.setSessionDataParameter(SESSION_STATE, sessionState ?? "")
+    );
 
     const _httpClient: HttpClientInstance = HttpClient.getInstance();
 
@@ -286,9 +290,7 @@ export const MainThreadClient = async (
             config.checkSessionInterval ?? 3,
             config.sessionRefreshInterval ?? 300,
             config.signInRedirectURL,
-            oidcEndpoints.authorizationEndpoint ?? "",
-            config.storage,
-            (sessionState: string) => _dataLayer.setSessionDataParameter(SESSION_STATE, sessionState ?? "")
+            oidcEndpoints.authorizationEndpoint ?? ""
         );
     };
 

--- a/lib/src/clients/web-worker-client.ts
+++ b/lib/src/clients/web-worker-client.ts
@@ -305,17 +305,18 @@ export const WebWorkerClient = (config: AuthClientConfig<WebWorkerClientConfig>)
 
     const checkSession = async (): Promise<void> => {
         const oidcEndpoints: OIDCEndpoints = await getOIDCServiceEndpoints();
-        const sessionState: string = (await getBasicUserInfo()).sessionState;
         const config: AuthClientConfig<WebWorkerClientConfig> = await getConfigData();
 
         _sessionManagementHelper.initialize(
             config.clientID,
             oidcEndpoints.checkSessionIframe ?? "",
-            sessionState,
+            async () => (await getBasicUserInfo()).sessionState,
             config.checkSessionInterval ?? 3,
             config.sessionRefreshInterval ?? 300,
             config.signInRedirectURL,
-            oidcEndpoints.authorizationEndpoint ?? ""
+            oidcEndpoints.authorizationEndpoint ?? "",
+            config.storage,
+            (sessionState: string) => setSessionState(sessionState)
         );
     };
 

--- a/lib/src/clients/web-worker-client.ts
+++ b/lib/src/clients/web-worker-client.ts
@@ -318,7 +318,8 @@ export const WebWorkerClient = (config: AuthClientConfig<WebWorkerClientConfig>)
             config.checkSessionInterval ?? 3,
             config.sessionRefreshInterval ?? 300,
             config.signInRedirectURL,
-            oidcEndpoints.authorizationEndpoint ?? ""
+            oidcEndpoints.authorizationEndpoint ?? "",
+            config.enablePKCE
         );
     };
 

--- a/lib/src/clients/web-worker-client.ts
+++ b/lib/src/clients/web-worker-client.ts
@@ -88,19 +88,23 @@ export const WebWorkerClient = (config: AuthClientConfig<WebWorkerClientConfig>)
      * API request time out.
      */
     const _requestTimeout: number = config?.requestTimeout ?? 60000;
-    const _sessionManagementHelper = SessionManagementHelper(async () => {
-        const message: Message<string> = {
-            type: SIGN_OUT
-        };
+    const _sessionManagementHelper = SessionManagementHelper(
+        async () => {
+            const message: Message<string> = {
+                type: SIGN_OUT
+            };
 
-        try {
-            const signOutURL = await communicate<string, string>(message);
+            try {
+                const signOutURL = await communicate<string, string>(message);
 
-            return signOutURL;
-        } catch {
-            return SPAUtils.getSignOutURL();
-        }
-    });
+                return signOutURL;
+            } catch {
+                return SPAUtils.getSignOutURL();
+            }
+        },
+        config.storage,
+        (sessionState: string) => setSessionState(sessionState)
+    );
 
     const worker: Worker = new WorkerFile();
 
@@ -314,9 +318,7 @@ export const WebWorkerClient = (config: AuthClientConfig<WebWorkerClientConfig>)
             config.checkSessionInterval ?? 3,
             config.sessionRefreshInterval ?? 300,
             config.signInRedirectURL,
-            oidcEndpoints.authorizationEndpoint ?? "",
-            config.storage,
-            (sessionState: string) => setSessionState(sessionState)
+            oidcEndpoints.authorizationEndpoint ?? ""
         );
     };
 

--- a/lib/src/constants/messages-types.ts
+++ b/lib/src/constants/messages-types.ts
@@ -46,3 +46,4 @@ export const GET_ID_TOKEN = "get_id_token";
 export const CHECK_SESSION_SIGNED_IN = "check_session_signed_in";
 export const CHECK_SESSION_SIGNED_OUT = "check_session_signed_out";
 export const GET_CONFIG_DATA = "get_config_data";
+export const SET_SESSION_STATE_FROM_IFRAME = "set_session_state_from_iframe";

--- a/lib/src/helpers/session-management-helper.ts
+++ b/lib/src/helpers/session-management-helper.ts
@@ -53,9 +53,7 @@ export const SessionManagementHelper = (() => {
         interval: number,
         sessionRefreshInterval: number,
         redirectURL: string,
-        authorizationEndpoint: string,
-        storage: Storage,
-        setSessionState: (sessionState: string) => void
+        authorizationEndpoint: string
     ): void => {
         _clientID = clientID;
         _checkSessionEndpoint = checkSessionEndpoint;
@@ -64,8 +62,6 @@ export const SessionManagementHelper = (() => {
         _redirectURL = redirectURL;
         _authorizationEndpoint = authorizationEndpoint;
         _sessionRefreshInterval = sessionRefreshInterval;
-        _storage = storage;
-        _setSessionState = setSessionState;
 
         if (_interval > -1) {
             initiateCheckSession();
@@ -272,7 +268,11 @@ export const SessionManagementHelper = (() => {
         return false;
     };
 
-    return (signOut: () => Promise<string>): SessionManagementHelperInterface => {
+    return (
+        signOut: () => Promise<string>,
+        storage: Storage,
+        setSessionState: (sessionState: string) => void
+    ): SessionManagementHelperInterface => {
         const opIFrame = document.createElement("iframe");
         opIFrame.setAttribute("id", OP_IFRAME);
         opIFrame.style.display = "none";
@@ -291,6 +291,9 @@ export const SessionManagementHelper = (() => {
         rpIFrame?.contentDocument?.body?.appendChild(promptNoneIFrame);
 
         _signOut = signOut;
+
+        _storage = storage;
+        _setSessionState = setSessionState;
 
         return {
             initialize,

--- a/lib/src/helpers/session-management-helper.ts
+++ b/lib/src/helpers/session-management-helper.ts
@@ -74,41 +74,27 @@ export const SessionManagementHelper = (() => {
         if (!_checkSessionEndpoint || !_clientID || !_redirectURL) {
             return;
         }
-        function startCheckSession(
-            checkSessionEndpoint: string,
-            clientID: string,
-            redirectURL: string,
-            sessionState: string,
-            interval: number
-        ): void {
-            const OP_IFRAME = "opIFrame";
 
-            function checkSession(): void {
-                if (Boolean(clientID) && Boolean(sessionState)) {
-                    const message = `${clientID} ${sessionState}`;
-                    const opIframe: HTMLIFrameElement = document.getElementById(OP_IFRAME) as HTMLIFrameElement;
-                    const win: Window | null = opIframe.contentWindow;
-                    win?.postMessage(message, checkSessionEndpoint);
-                }
+        const OP_IFRAME = "opIFrame";
+
+        function checkSession(): void {
+            if (Boolean(_clientID) && Boolean(_sessionState)) {
+                const message = `${ _clientID } ${ _sessionState }`;
+                const rpIFrame = document.getElementById(RP_IFRAME) as HTMLIFrameElement;
+                const opIframe: HTMLIFrameElement
+                    = rpIFrame?.contentWindow?.document.getElementById(OP_IFRAME) as HTMLIFrameElement;
+                const win: Window | null = opIframe.contentWindow;
+                win?.postMessage(message, _checkSessionEndpoint);
             }
-
-            const opIframe: HTMLIFrameElement = document.getElementById(OP_IFRAME) as HTMLIFrameElement;
-            opIframe.src = checkSessionEndpoint + "?client_id=" + clientID + "&redirect_uri=" + redirectURL;
-            checkSession();
-
-            _checkSessionIntervalTimeout =  setInterval(checkSession, interval * 1000) as unknown as number;
         }
 
         const rpIFrame = document.getElementById(RP_IFRAME) as HTMLIFrameElement;
-        (rpIFrame.contentWindow as any).eval(startCheckSession.toString());
-        rpIFrame?.contentWindow &&
-            rpIFrame?.contentWindow[startCheckSession.name](
-                _checkSessionEndpoint,
-                _clientID,
-                _redirectURL,
-                _sessionState,
-                _interval
-            );
+        const opIframe: HTMLIFrameElement
+            = rpIFrame?.contentWindow?.document.getElementById(OP_IFRAME) as HTMLIFrameElement;
+        opIframe.src = _checkSessionEndpoint + "?client_id=" + _clientID + "&redirect_uri=" + _redirectURL;
+        checkSession();
+
+        _checkSessionIntervalTimeout =  setInterval(checkSession, _interval * 1000) as unknown as number;
 
         listenToResponseFromOPIFrame();
     };
@@ -133,8 +119,6 @@ export const SessionManagementHelper = (() => {
     };
 
     const listenToResponseFromOPIFrame = (): void => {
-        const rpIFrame = document.getElementById(RP_IFRAME) as HTMLIFrameElement;
-
         async function receiveMessage(e) {
             const targetOrigin = _checkSessionEndpoint;
 
@@ -152,7 +136,7 @@ export const SessionManagementHelper = (() => {
             }
         }
 
-        rpIFrame?.contentWindow?.addEventListener("message", receiveMessage, false);
+        window?.addEventListener("message", receiveMessage, false);
     };
 
     const sendPromptNoneRequest = () => {

--- a/lib/src/models/message.ts
+++ b/lib/src/models/message.ts
@@ -43,6 +43,7 @@ import {
     REQUEST_SUCCESS,
     REVOKE_ACCESS_TOKEN,
     SET_SESSION_STATE,
+    SET_SESSION_STATE_FROM_IFRAME,
     SIGN_IN,
     SIGN_OUT,
     START_AUTO_REFRESH_TOKEN,
@@ -97,7 +98,8 @@ export type MessageType =
     | typeof GET_ID_TOKEN
     | typeof CHECK_SESSION_SIGNED_IN
     | typeof CHECK_SESSION_SIGNED_OUT
-    | typeof GET_CONFIG_DATA;
+    | typeof GET_CONFIG_DATA
+    | typeof SET_SESSION_STATE_FROM_IFRAME;
 
 export interface CommunicationHelperInterface {
     communicate: <T, R>(message: Message<T>) => Promise<R>;

--- a/lib/src/models/session-management-helper.ts
+++ b/lib/src/models/session-management-helper.ts
@@ -16,15 +16,19 @@
  * under the License.
  */
 
+import { Storage } from "../constants";
+
 export interface SessionManagementHelperInterface {
     initialize(
         clientID: string,
         checkSessionEndpoint: string,
-        sessionState: string,
+        getSessionState: () => Promise<string>,
         interval: number,
         sessionRefreshInterval: number,
         redirectURL: string,
         authorizationEndpoint: string,
+        storage?: Storage,
+        setSessionState?: (sessionState: string) => void
     ): void;
     receivePromptNoneResponse(
         setSessionState?: (sessionState: string | null) => Promise<void>

--- a/lib/src/models/session-management-helper.ts
+++ b/lib/src/models/session-management-helper.ts
@@ -16,8 +16,6 @@
  * under the License.
  */
 
-import { Storage } from "../constants";
-
 export interface SessionManagementHelperInterface {
     initialize(
         clientID: string,
@@ -26,9 +24,7 @@ export interface SessionManagementHelperInterface {
         interval: number,
         sessionRefreshInterval: number,
         redirectURL: string,
-        authorizationEndpoint: string,
-        storage?: Storage,
-        setSessionState?: (sessionState: string) => void
+        authorizationEndpoint: string
     ): void;
     receivePromptNoneResponse(
         setSessionState?: (sessionState: string | null) => Promise<void>

--- a/lib/src/models/session-management-helper.ts
+++ b/lib/src/models/session-management-helper.ts
@@ -24,7 +24,8 @@ export interface SessionManagementHelperInterface {
         interval: number,
         sessionRefreshInterval: number,
         redirectURL: string,
-        authorizationEndpoint: string
+        authorizationEndpoint: string,
+        isPKCEEnabled?: boolean
     ): void;
     receivePromptNoneResponse(
         setSessionState?: (sessionState: string | null) => Promise<void>


### PR DESCRIPTION
## Purpose
> This PR addresses the following bugs:
1. When the storage is set to `webWorker`, the session state was not getting updated with the value returned by the prompt-none authorization call.
2. The authorization request generated to check session did not account for `?` already there in the authorization endpoint URL.