### PR TITLE
Fix sign out bug when check session returns an error

### DIFF
--- a/lib/src/helpers/session-management-helper.ts
+++ b/lib/src/helpers/session-management-helper.ts
@@ -137,7 +137,7 @@ export const SessionManagementHelper = (() => {
             if (e.data === "unchanged") {
                 // [RP] session state has not changed
             } else if (e.data === "error") {
-                window.parent.location.href = await _signOut();
+                window.location.href = await _signOut();
             } else {
                 // [RP] session state has changed. Sending prompt=none request...
                 sendPromptNoneRequest();


### PR DESCRIPTION
## Purpose
>  This https://github.com/asgardeo/asgardeo-auth-spa-sdk/pull/54 PR moved the check session logic from the `rpIFrame` to the main frame. This resulted in the user not getting signed out when the check session message response returns an error. This PR addresses this issue. 