### PR TITLE
Allow http request body to be encoded into a FormData object

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,7 +409,12 @@ httpRequest(config: HttpRequestConfig): Promise<HttpResponse>;
 #### Arguments
 
 1. config: `[HttpRequestConfig](#httpRequestConfig)`
-   A config object with the settings necessary to send http requests. This object is similar to the `AxiosRequestConfig` but provides an additional attribute called `attachToken` to allow you to specify if the access token should be attached to the request.
+   A config object with the settings necessary to send http requests. This object is similar to the `AxiosRequestConfig` but provides these additional attributes:
+
+   |Attribute|Type|Default|Description|
+   |--|--|--|--|
+   |`attachToken`|`boolean`|`true`|If set to `true`, the token will be attached to the request header.|
+   |`shouldEncodeToFormData`|`boolean`|`false`|If set to `true`, the request body will be encoded to `FormData`.|
 
 #### Returns
 

--- a/lib/src/http-client/clients/axios-http-client.ts
+++ b/lib/src/http-client/clients/axios-http-client.ts
@@ -133,6 +133,16 @@ export class HttpClient implements HttpClientInterface<HttpRequestConfig, HttpRe
     public async requestHandler(request: HttpRequestConfig): Promise<HttpRequestConfig> {
         await this.attachToken(request);
 
+        if (request?.shouldEncodeToFormData) {
+            const data = request?.data;
+            const formData = new FormData();
+            Object.keys(data).forEach((key) => {
+                formData.append(key, data[key]);
+            });
+
+            request.data = formData;
+        }
+
         if (HttpClient.isHandlerEnabled) {
             if (this.requestStartCallback && typeof this.requestStartCallback === "function") {
                 this.requestStartCallback(request);

--- a/lib/src/models/http-client.ts
+++ b/lib/src/models/http-client.ts
@@ -28,6 +28,7 @@ export interface HttpClient {
 
 export interface HttpRequestConfig extends AxiosRequestConfig {
     attachToken?: boolean;
+    shouldEncodeToFormData?: boolean;
 }
 
 export {

--- a/samples/asgardeo-html-js-app/app.js
+++ b/samples/asgardeo-html-js-app/app.js
@@ -183,24 +183,22 @@ if (authConfig.clientID === "") {
 } else {
     // Check if the page redirected by the sign-in method with authorization code, if it is recall sing-in method to
     // continue the sign-in flow
-    if (JSON.parse(sessionStorage.getItem("initialized-sign-in"))) {
-        authClient.signIn({ callOnlyOnRedirect: true }).catch((error)=> {
-            document.getElementById("loading").style.display = "none";
-            document.getElementById("error").style.display = "block";
-        });
-    } else {
-        authClient.isAuthenticated().then(function(isAuthenticated) {
-            if (isAuthenticated) {
-                authClient.getIDToken().then(function(idToken) {
-                    state.authenticateResponse = JSON.parse(sessionStorage.getItem("authenticateResponse"));
-                    state.idToken = parseIdToken(idToken);
-                    state.isAuth = true;
+    authClient.signIn({ callOnlyOnRedirect: true }).catch((error) => {
+        document.getElementById("loading").style.display = "none";
+        document.getElementById("error").style.display = "block";
+    });
 
-                    updateView();
-                });
-            } else {
+    authClient.isAuthenticated().then(function (isAuthenticated) {
+        if (isAuthenticated) {
+            authClient.getIDToken().then(function (idToken) {
+                state.authenticateResponse = JSON.parse(sessionStorage.getItem("authenticateResponse"));
+                state.idToken = parseIdToken(idToken);
+                state.isAuth = true;
+
                 updateView();
-            }
-        });
-    }
+            });
+        } else {
+            updateView();
+        }
+    });
 }


### PR DESCRIPTION
## Purpose
> This PR introduces a flag called `shouldEncodeToFormData`, which when set to `true` will encode the data object passed into a `FormData` object.