### PR TITLE
Fix html sample error when performing federated authentication

### DIFF
--- a/samples/asgardeo-html-js-app/app.js
+++ b/samples/asgardeo-html-js-app/app.js
@@ -41,7 +41,7 @@ var state = {
 authClient.on("sign-in", function (response) {
     var username = response?.username?.split("/");
 
-    if (username.length >= 2) {
+    if (username?.length >= 2) {
         username.shift();
         response.username = username.join("/");
     }


### PR DESCRIPTION
## Purpose
> Added a null check to prevent an error from being thrown when the username is undefined or nulll. The username being null or undefined resulted in an error being shown on the sample app.  
