### PR TITLE
Add `sub` attribute to Authenticated state

### DIFF
--- a/README.md
+++ b/README.md
@@ -948,6 +948,7 @@ This table shows the extended attributes provided by the `Config` interface.
 | `allowedScopes` | `string` | The scopes allowed for the user.                                                                   |
 | `tenantDomain`  | `string` | The tenant domain to which the user belongs.                                                       |
 | `sessionState`  | `string` | The session state.                                                                                 |
+| `sub`           | `string` | The `uid` corresponding to the user to whom the ID token belongs to.                               |
 
 ### SignInConfig
 

--- a/lib/package-lock.json
+++ b/lib/package-lock.json
@@ -5,9 +5,9 @@
 	"requires": true,
 	"dependencies": {
 		"@asgardeo/auth-js": {
-			"version": "0.2.17",
-			"resolved": "https://registry.npmjs.org/@asgardeo/auth-js/-/auth-js-0.2.17.tgz",
-			"integrity": "sha512-bo59SJvGkwZdbFCc3ejtJEiJPZsaByq4tWe4UuxoyPEeEV1h/FWpAoAjKt6kKGAR8sDAuEMbVUMO51O09QOAYQ==",
+			"version": "0.2.18",
+			"resolved": "https://registry.npmjs.org/@asgardeo/auth-js/-/auth-js-0.2.18.tgz",
+			"integrity": "sha512-qJtOttRXdJ+uiDKfUuzSOU5Ty3/VfCVXSmcCq+8WVyYSr4o7twCBKK6ZwWW0ixqJ4xCczJrGa5ozzeVL+gN20A==",
 			"requires": {
 				"base64url": "^3.0.1",
 				"fast-sha256": "^1.3.0",

--- a/lib/package.json
+++ b/lib/package.json
@@ -25,7 +25,7 @@
     "author": "Asgardeo",
     "license": "Apache-2.0",
     "dependencies": {
-        "@asgardeo/auth-js": "^0.2.17",
+        "@asgardeo/auth-js": "^0.2.18",
         "@babel/runtime-corejs3": "^7.11.2",
         "await-semaphore": "^0.1.3",
         "axios": "^0.21.0",

--- a/lib/src/clients/main-thread-client.ts
+++ b/lib/src/clients/main-thread-client.ts
@@ -315,6 +315,7 @@ export const MainThreadClient = async (
                 displayName: "",
                 email: "",
                 sessionState: "",
+                sub: "",
                 tenantDomain: "",
                 username: ""
             });
@@ -383,6 +384,7 @@ export const MainThreadClient = async (
                 displayName: "",
                 email: "",
                 sessionState: "",
+                sub: "",
                 tenantDomain: "",
                 username: ""
             });
@@ -529,6 +531,7 @@ export const MainThreadClient = async (
                 displayName: "",
                 email: "",
                 sessionState: "",
+                sub: "",
                 tenantDomain: "",
                 username: ""
             });

--- a/lib/src/clients/web-worker-client.ts
+++ b/lib/src/clients/web-worker-client.ts
@@ -342,6 +342,7 @@ export const WebWorkerClient = (config: AuthClientConfig<WebWorkerClientConfig>)
                 displayName: "",
                 email: "",
                 sessionState: "",
+                sub: "",
                 tenantDomain: "",
                 username: ""
             });
@@ -480,6 +481,7 @@ export const WebWorkerClient = (config: AuthClientConfig<WebWorkerClientConfig>)
                 displayName: "",
                 email: "",
                 sessionState: "",
+                sub: "",
                 tenantDomain: "",
                 username: ""
             });
@@ -553,6 +555,7 @@ export const WebWorkerClient = (config: AuthClientConfig<WebWorkerClientConfig>)
                     displayName: "",
                     email: "",
                     sessionState: "",
+                    sub: "",
                     tenantDomain: "",
                     username: ""
                 });


### PR DESCRIPTION
## Purpose
Bring in changes done in https://github.com/asgardeo/asgardeo-auth-js-sdk/pull/163 to enable returning the `sub` from the `id_token` as a high level item via the Authenticated State.

## Goals
Address https://github.com/asgardeo/asgardeo-auth-react-sdk/issues/64

## Approach
Refer https://github.com/asgardeo/asgardeo-auth-js-sdk/pull/163

## User stories
None

## Release note
None

## Documentation
None

## Training
None

## Certification
None

## Marketing
None

## Automation tests
None

## Security checks
None

## Samples
None

## Related PRs
None

## Migrations (if applicable)
None

## Test environment
None
 
## Learning
None