### PR TITLE
Ensuring the Compatibility of the SDK After signOut Method Was Removed From Auth JS SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,7 +401,7 @@ The `sign-out` hook is used to fire a callback function after signing out is suc
 auth.signOut();
 ```
 
-**Clearing the locally stored user session happens when a sign-out hook is registered after the user got redirected back to the `signOutRedirectURL`.**
+**Clearing the locally stored user session happens when a sign-out hook is registered after the user gets redirected back to the `signOutRedirectURL`.**
 Therefore, the developer should ensure that a sign-out hook is registered when `signOutRedirectURL` is loaded. Refer the [example](#sign-out-hook-example) 
 for further details.
 

--- a/README.md
+++ b/README.md
@@ -401,6 +401,17 @@ The `sign-out` hook is used to fire a callback function after signing out is suc
 auth.signOut();
 ```
 
+**Clearing the locally stored user session happens when a sign-out hook is registered after the user got redirected back to the `signOutRedirectURL`.**
+Therefore, the developer should ensure that a sign-out hook is registered when `signOutRedirectURL` is loaded. Refer the [example](#sign-out-hook-example) 
+for further details.
+
+#### Example
+```TypeScript
+// Register a sign-out hook with any callback function when signOutRedirectURL is loaded 
+// to clear locally stored user session
+auth.on("sign-out", () => {});
+```
+
 ---
 
 ### httpRequest
@@ -807,7 +818,6 @@ If you are using TypeScript, you may want to use the `Hooks` enum that consists 
 **When the user signs out, the user is taken to the Asgardeo's logout page and then redirected back to the SPA on successful log out. Hence, developers should ensure that the `"sign-out"` hook is called when the page the user is redirected to loads.**
 
 #### Example
-
 ```TypeScript
 auth.on("sign-in", () => {
     // console.log(response);

--- a/lib/src/clients/main-thread-client.ts
+++ b/lib/src/clients/main-thread-client.ts
@@ -80,7 +80,7 @@ export const MainThreadClient = async (
     const _dataLayer = _authenticationClient.getDataLayer();
     const _sessionManagementHelper = await SessionManagementHelper(
         async () => {
-            return _authenticationClient.signOut();
+            return _authenticationClient.getSignOutURL();
         },
         config.storage ?? Storage.SessionStorage,
         (sessionState: string) => _dataLayer.setSessionDataParameter(SESSION_STATE, sessionState ?? "")
@@ -252,7 +252,7 @@ export const MainThreadClient = async (
 
     const signOut = async (): Promise<boolean> => {
         if ((await _authenticationClient.isAuthenticated()) && !_getSignOutURLFromSessionStorage) {
-            location.href = await _authenticationClient.signOut();
+            location.href = await _authenticationClient.getSignOutURL();
         } else {
             location.href = SPAUtils.getSignOutURL();
             await _dataLayer.removeOIDCProviderMetaData();

--- a/lib/src/worker/worker-core.ts
+++ b/lib/src/worker/worker-core.ts
@@ -156,7 +156,7 @@ export const WebWorkerCore = async (
     const signOut = async (): Promise<string> => {
         _spaHelper.clearRefreshTokenTimeout();
 
-        return await _authenticationClient.signOut();
+        return await _authenticationClient.getSignOutURL();
     };
 
     const getSignOutURL = async (): Promise<string> => {


### PR DESCRIPTION
## Purpose
> Make the Auth SPA SDK compatible with the changes done in the PR https://github.com/asgardeo/asgardeo-auth-js-sdk/pull/212 as suggested in issue https://github.com/asgardeo/asgardeo-auth-js-sdk/issues/211 and provide more details on how the locally stored user session cleared when the user is logging out.

## Approach
> The following changes were done to the Auth SPA SDK.

- Replaced the instances where the signOut method from Auth JS SDK was used by getSignOutURL method.
- Supplement the description of signOut method with information on clearing locally stored user sessions.

