### PR TITLE
Fix locally stored user session data not being cleared when single logout is triggered.

### DIFF
--- a/lib/src/helpers/session-management-helper.ts
+++ b/lib/src/helpers/session-management-helper.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { GetAuthURLConfig, SESSION_STATE } from "@asgardeo/auth-js";
+import { AsgardeoAuthClient, GetAuthURLConfig, SESSION_STATE } from "@asgardeo/auth-js";
 import {
     CHECK_SESSION_SIGNED_IN,
     CHECK_SESSION_SIGNED_OUT,
@@ -243,7 +243,11 @@ export const SessionManagementHelper = (() => {
 
                 SPAUtils.setPromptNoneRequestSent(false);
 
-                parent.location.href = await _signOut();
+                const signOutURL = await _signOut();
+                // Clearing user session data before redirecting to the signOutURL because user has been already logged
+                // out by the initial logout request in the single logout flow.
+                await AsgardeoAuthClient.clearUserSessionData();
+                parent.location.href = signOutURL;
                 window.location.href = "about:blank";
 
                 await SPAUtils.waitTillPageRedirect();


### PR DESCRIPTION
## Purpose
> Fixes https://github.com/asgardeo/asgardeo-auth-spa-sdk/issues/117

## Approach
> The cause of the issue was that in the single logout flow, only the first log-out request would get a `state=sign_out_success` parameter from Asgardeo. As a result, locally stored user session data of all the subsequent logout requests will not be cleared since they are only cleared when the `state` parameter is `sign_out_success` at the `signOutRedirectURL`. 
>
> To resolve the issue, locally stored user session data is now cleared before sending the subsequent logout requests in the single logout flow since the user has been already logged out by the initial logout request.





