### PR TITLE
Fix refresh token timer not being cleared when revokeAccessToken method is called

### DIFF
--- a/lib/src/helpers/spa-helper.ts
+++ b/lib/src/helpers/spa-helper.ts
@@ -47,13 +47,28 @@ export class SPAHelper<T extends MainThreadClientConfig | WebWorkerClientConfig>
         }
     }
 
-    public async clearRefreshTokenTimeout(): Promise<void> {
+    public async getRefreshTimeoutTimer(): Promise<number> {
         if (await this._dataLayer.getTemporaryDataParameter(REFRESH_TOKEN_TIMER)) {
-            const oldTimer = JSON.parse(
+            return JSON.parse(
                 (await this._dataLayer.getTemporaryDataParameter(REFRESH_TOKEN_TIMER)) as string
             );
+        }
 
-            clearTimeout(oldTimer);
+        return -1;
+    }
+
+
+    public async clearRefreshTokenTimeout(timer?: number): Promise<void> {
+        if (timer) {
+            clearTimeout(timer);
+
+            return;
+        }
+
+        const refreshTimer: number = await this.getRefreshTimeoutTimer();
+
+        if (refreshTimer !== -1) {
+            clearTimeout(refreshTimer);
         }
     }
 }

--- a/lib/src/helpers/spa-helper.ts
+++ b/lib/src/helpers/spa-helper.ts
@@ -57,7 +57,6 @@ export class SPAHelper<T extends MainThreadClientConfig | WebWorkerClientConfig>
         return -1;
     }
 
-
     public async clearRefreshTokenTimeout(timer?: number): Promise<void> {
         if (timer) {
             clearTimeout(timer);

--- a/lib/src/worker/worker-core.ts
+++ b/lib/src/worker/worker-core.ts
@@ -56,7 +56,7 @@ export const WebWorkerCore = async (
 
     const _spaHelper = new SPAHelper<WebWorkerClientConfig>(_authenticationClient);
 
-    const _authenticationHelper: AuthenticationHelper<WebWorkerClientConfig> = 
+    const _authenticationHelper: AuthenticationHelper<WebWorkerClientConfig> =
         getAuthHelper(_authenticationClient, _spaHelper);
 
     const _dataLayer = _authenticationClient.getDataLayer();
@@ -93,7 +93,7 @@ export const WebWorkerCore = async (
     const setHttpRequestFinishCallback = (callback: () => void): void => {
         _httpClient?.setHttpRequestFinishCallback && _httpClient.setHttpRequestFinishCallback(callback);
     };
-    
+
     const httpRequest = async (
         requestConfig: HttpRequestConfig
     ): Promise<HttpResponse> => {
@@ -175,11 +175,13 @@ export const WebWorkerCore = async (
         }
     };
 
-    const revokeAccessToken = (): Promise<boolean> => {
+    const revokeAccessToken = async (): Promise<boolean> => {
+        const timer: number = await _spaHelper.getRefreshTimeoutTimer();
+
         return _authenticationClient
             .revokeAccessToken()
             .then(() => {
-                _spaHelper.clearRefreshTokenTimeout();
+                _spaHelper.clearRefreshTokenTimeout(timer);
 
                 return Promise.resolve(true);
             })


### PR DESCRIPTION
## Purpose
> The timer number is obtained from the temporary store to clear the refresh timer. However, when the revokeAccessToken method is called, it clears the temporary store. This means the refresh token timer could not be cleared. 

> This PR addresses this issue by temporarily storing the timer value in a variable before the token is revoked and then using this value to clear the timer after the revocation is successful.
