### PR TITLE
Allow httpRequest() method to bypass user authentication validation if the attachToken config is set to false.

### DIFF
--- a/lib/src/client.ts
+++ b/lib/src/client.ts
@@ -145,7 +145,7 @@ export class AsgardeoSPAClient {
      *
      * @private
      */
-    private async _validateMethod(): Promise<boolean> {
+    private async _validateMethod(validateAuthentication: boolean = true): Promise<boolean> {
         if (!(await this._isInitialized())) {
             return Promise.reject(
                 new AsgardeoAuthException(
@@ -156,7 +156,7 @@ export class AsgardeoSPAClient {
             );
         }
 
-        if (!(await this.isAuthenticated())) {
+        if (validateAuthentication && !(await this.isAuthenticated())) {
             return Promise.reject(
                 new AsgardeoAuthException(
                     "SPA-AUTH_CLIENT-VM-IV02",
@@ -492,7 +492,7 @@ export class AsgardeoSPAClient {
      * @preserve
      */
     public async httpRequest(config: HttpRequestConfig): Promise<HttpResponse | undefined> {
-        await this._validateMethod();
+        await this._validateMethod(config.attachToken);
 
         return this._client?.httpRequest(config);
     }


### PR DESCRIPTION
## Purpose
> Adding functionality mentioned in the issue https://github.com/asgardeo/asgardeo-auth-spa-sdk/issues/133.

## Goals
> This will eliminate the need for maintaining a separate HTTP client inside the application if the developers want to make unauthenticated API calls to a public API.

## Approach
> Making `_validateMethod()` bypass the user authentication validation according to the value of the `attachToken` config when calling the `httpRequest()` method.

