### PR TITLE
Move the attach token logic to authentication-helper

### DIFF
--- a/lib/src/clients/main-thread-client.ts
+++ b/lib/src/clients/main-thread-client.ts
@@ -96,21 +96,7 @@ export const MainThreadClient = async (
     let _httpFinishCallback: () => void;
 
     const attachToken = async (request: HttpRequestConfig): Promise<void> => {
-        const requestConfig = { attachToken: true, ...request };
-
-        if (requestConfig.attachToken) {
-            if(requestConfig.shouldAttachIDPAccessToken) {
-                request.headers = {
-                    ...request.headers,
-                    Authorization: `Bearer ${ await _authenticationHelper.getIDPAccessToken() }`
-                };
-            } else {
-                request.headers = {
-                    ...request.headers,
-                    Authorization: `Bearer ${ await _authenticationHelper.getAccessToken() }`
-                };
-            }
-        }
+        await _authenticationHelper.attachTokenToRequestConfig(request);
     }
 
     _httpClient?.init && (await _httpClient.init(true, attachToken));

--- a/lib/src/helpers/authentication-helper.ts
+++ b/lib/src/helpers/authentication-helper.ts
@@ -602,6 +602,23 @@ export class AuthenticationHelper<
         }
     }
 
+    public async attachTokenToRequestConfig(request : HttpRequestConfig): Promise<void> {
+        const requestConfig = { attachToken: true, ...request };
+        if (requestConfig.attachToken) {
+            if(requestConfig.shouldAttachIDPAccessToken) {
+                request.headers = {
+                    ...request.headers,
+                    Authorization: `Bearer ${ await this.getIDPAccessToken() }`
+                };
+            } else {
+                request.headers = {
+                    ...request.headers,
+                    Authorization: `Bearer ${ await this.getAccessToken() }`
+                };
+            }
+        }
+    }
+
     public async getBasicUserInfo(): Promise<BasicUserInfo> {
         return this._authenticationClient.getBasicUserInfo();
     }

--- a/lib/src/worker/worker-core.ts
+++ b/lib/src/worker/worker-core.ts
@@ -64,20 +64,7 @@ export const WebWorkerCore = async (
     const _httpClient: HttpClientInstance = HttpClient.getInstance();
 
     const attachToken = async (request: HttpRequestConfig): Promise<void> => {
-        const requestConfig = { attachToken: true, ...request };
-        if (requestConfig.attachToken) {
-            if(requestConfig.shouldAttachIDPAccessToken) {
-                request.headers = {
-                    ...request.headers,
-                    Authorization: `Bearer ${ await _authenticationHelper.getIDPAccessToken() }`
-                };
-            } else {
-                request.headers = {
-                    ...request.headers,
-                    Authorization: `Bearer ${ await _authenticationHelper.getAccessToken() }`
-                };
-            }
-        }
+        await _authenticationHelper.attachTokenToRequestConfig(request);
     };
 
     _httpClient?.init && (await _httpClient.init(true, attachToken));


### PR DESCRIPTION
## Purpose
> Moving the attach token logic to authentication-helper so that logic can be customised by token-exchange-plugin