### PR TITLE
BREAKING CHANGE: Stop transforming custom auth params

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -25,7 +25,7 @@
     "author": "Asgardeo",
     "license": "Apache-2.0",
     "dependencies": {
-        "@asgardeo/auth-js": "^4.1.2",
+        "@asgardeo/auth-js": "^5.0.0",
         "await-semaphore": "^0.1.3",
         "axios": "^0.26.0",
         "base64url": "^3.0.1",

--- a/lib/yarn.lock
+++ b/lib/yarn.lock
@@ -10,10 +10,10 @@
     "@jridgewell/gen-mapping" "^0.1.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@asgardeo/auth-js@^4.1.2":
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/@asgardeo/auth-js/-/auth-js-4.1.2.tgz#92cfd3914e86b14fbd59078599bdc47c1ec4fbd0"
-  integrity sha512-CYpKxQMFtxBUcp7NntlA+OoQ4BGXWLjJPYTJdMJAcU1K9GGdxGq6CvHfHGSmJ2l1qDksa8ZkCHnG/IwlDKaUqA==
+"@asgardeo/auth-js@^5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@asgardeo/auth-js/-/auth-js-5.0.0.tgz#ad63c232ac0588363e95c54d576c6318a6d4be93"
+  integrity sha512-BMQsTzpFwtgbSeJvmSDgRrOjXfA6+yQ2NUq7CXP4q1TtqZJt8s/zadOazPM00/jIY8B2ENS0CLRHp07M0mFdOw==
 
 "@babel/cli@^7.17.6":
   version "7.18.9"


### PR DESCRIPTION
## Purpose
This PR addresses the issue reported in [asgardeo/asgardeo-auth-react-sdk#208](https://github.com/asgardeo/asgardeo-auth-react-sdk/issues/208), where the keys passed into the `signIn` hook are transformed into *Snake Case*, causing compatibility issues.

Fix was added to `@asgardeo/auth-js`.

- @asgardeo/auth-js: https://github.com/asgardeo/asgardeo-auth-js-core/pull/249

## Goals
- Resolve [asgardeo/asgardeo-auth-react-sdk#208](https://github.com/asgardeo/asgardeo-auth-react-sdk/issues/208)

## Approach
The issue was introduced with the changes in [asgardeo/asgardeo-auth-js-core#203](https://github.com/asgardeo/asgardeo-auth-js-core/pull/203/files#diff-f34c1fc70c8dfe6982556af3ab69b70a42b7a68c9119cfa0bfa4716acd929750R120). The approach involves reverting the specific change that introduced the undesired key transformation.

*Before*

<img width="619" alt="Screenshot 2023-12-20 at 18 21 33" src="https://github.com/asgardeo/asgardeo-auth-js-core/assets/25959096/ecc740ec-e030-477d-b5a0-3ebd16c40f3c">

*After*

<img width="609" alt="Screenshot 2023-12-20 at 18 42 38" src="https://github.com/asgardeo/asgardeo-auth-js-core/assets/25959096/618038e3-e4af-4d62-b9e4-079dfd74ea49">

## User stories
- Users should be able to pass custom parameters to the `signIn` hook without having the keys transformed.

## Release note
🔥 BREAKING CHANGE: Fixed an issue where custom parameters passed to the `signIn` hook were transformed into *Snake Case*, causing compatibility issues.

## Documentation
N/A (No documentation impact)

## Training
N/A (No training impact)

## Certification
N/A (No impact on certification exams)

## Marketing
N/A (No marketing impact)

## Automation tests
- Unit tests: Included with code coverage information
- Integration tests: Details about the test cases and coverage

## Security checks
- Followed secure coding standards in [WSO2 Secure Engineering Guidelines](http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes)
- Ran FindSecurityBugs plugin and verified report? yes
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A (No sample impact)

## Related PRs
- PR that introduced the issue: https://github.com/asgardeo/asgardeo-auth-js-core/pull/203

## Migrations (if applicable)
N/A (No migration steps required)

## Test environment
Tested on JDK versions, operating systems, databases, and browser/versions as follows:
- JDK: 11
- OS: Mac
- Database: H2
- Browser: Chrome

## Learning
The research phase involved an analysis of the introduced changes in [asgardeo/asgardeo-auth-js-core#203](https://github.com/asgardeo/asgardeo-auth-js-core/pull/203/files#diff-f34c1fc70c8dfe6982556af3ab69b70a42b7a68c9119cfa0bfa4716acd929750R120).
