### PR TITLE
Support additional params in trySignInSilently URL

### DIFF
--- a/lib/src/client.ts
+++ b/lib/src/client.ts
@@ -408,7 +408,9 @@ export class AsgardeoSPAClient {
      * auth.trySignInSilently()
      *```
      */
-    public async trySignInSilently(): Promise<BasicUserInfo | boolean | undefined> {
+    public async trySignInSilently(
+        additionalParams?: Record<string, string | boolean>
+    ): Promise<BasicUserInfo | boolean | undefined> {
         await this._isInitialized();
 
         // checks if the `signIn` method has been called.
@@ -416,7 +418,7 @@ export class AsgardeoSPAClient {
             return;
         }
 
-        return this._client?.trySignInSilently().then((response: BasicUserInfo | boolean) => {
+        return this._client?.trySignInSilently(additionalParams).then((response: BasicUserInfo | boolean) => {
             if (this._onSignInCallback && response) {
                 const basicUserInfo = response as BasicUserInfo;
                 if (

--- a/lib/src/clients/main-thread-client.ts
+++ b/lib/src/clients/main-thread-client.ts
@@ -315,11 +315,14 @@ export const MainThreadClient = async (
         );
     };
 
-    const constructSilentSignInUrl = async (): Promise<string> => {
+    const constructSilentSignInUrl = async (
+        additionalParams: Record<string, string | boolean> = {}
+    ): Promise<string> => {
         const config = await _dataLayer.getConfigData();
         const urlString: string = await _authenticationClient.getAuthorizationURL({
             prompt: "none",
-            state: SILENT_SIGN_IN_STATE
+            state: SILENT_SIGN_IN_STATE,
+            ...additionalParams
         });
 
         // Replace form_post with query
@@ -346,12 +349,15 @@ export const MainThreadClient = async (
      * @return {Promise<BasicUserInfo|boolean} Returns a Promise that resolves with the BasicUserInfo
      * if the user is signed in or with `false` if there is no active user session in the server.
      */
-    const trySignInSilently = async (): Promise<BasicUserInfo | boolean> => {
+    const trySignInSilently = async (
+        additionalParams: Record<string, string | boolean> = {}
+    ): Promise<BasicUserInfo | boolean> => {
 
         return await _authenticationHelper.trySignInSilently(
             constructSilentSignInUrl,
             requestAccessToken,
-            _sessionManagementHelper
+            _sessionManagementHelper,
+            additionalParams
         );
     };
 

--- a/lib/src/clients/web-worker-client.ts
+++ b/lib/src/clients/web-worker-client.ts
@@ -392,12 +392,15 @@ export const WebWorkerClient = async (
         );
     };
 
-    const constructSilentSignInUrl = async (): Promise<string> => {
+    const constructSilentSignInUrl = async (
+        additionalParams: Record<string, string | boolean> = {}
+    ): Promise<string> => {
         const config: AuthClientConfig<WebWorkerClientConfig> = await getConfigData();
         const message: Message<GetAuthURLConfig> = {
             data: {
                 prompt: "none",
-                state: SILENT_SIGN_IN_STATE
+                state: SILENT_SIGN_IN_STATE,
+                ...additionalParams
             },
             type: GET_AUTH_URL
         };
@@ -427,11 +430,14 @@ export const WebWorkerClient = async (
      * @return {Promise<BasicUserInfo|boolean} Returns a Promise that resolves with the BasicUserInfo
      * if the user is signed in or with `false` if there is no active user session in the server.
      */
-    const trySignInSilently = async (): Promise<BasicUserInfo | boolean> => {
+    const trySignInSilently = async (
+        additionalParams: Record<string, string | boolean> = {}
+    ): Promise<BasicUserInfo | boolean> => {
         return await _authenticationHelper.trySignInSilently(
             constructSilentSignInUrl,
             requestAccessToken,
-            _sessionManagementHelper
+            _sessionManagementHelper,
+            additionalParams
         );
     };
 

--- a/lib/src/helpers/authentication-helper.ts
+++ b/lib/src/helpers/authentication-helper.ts
@@ -489,9 +489,10 @@ export class AuthenticationHelper<
     }
 
     public async trySignInSilently(
-        constructSilentSignInUrl: () => Promise<string>,
+        constructSilentSignInUrl: (additionalParams?: Record<string, string | boolean>) => Promise<string>,
         requestAccessToken: (authzCode: string, sessionState: string, state: string) => Promise<BasicUserInfo>,
-        sessionManagementHelper: SessionManagementHelperInterface
+        sessionManagementHelper: SessionManagementHelperInterface,
+        additionalParams?: Record<string, string | boolean>
     ): Promise<BasicUserInfo | boolean> {
 
         // This block is executed by the iFrame when the server redirects with the authorization code.
@@ -517,7 +518,7 @@ export class AuthenticationHelper<
         ) as HTMLIFrameElement;
 
         try {
-            const url = await constructSilentSignInUrl();
+            const url = await constructSilentSignInUrl(additionalParams);
 
             promptNoneIFrame.src = url;
         } catch (error) {

--- a/lib/src/models/client.ts
+++ b/lib/src/models/client.ts
@@ -65,7 +65,7 @@ export interface MainThreadClientInterface {
     getDataLayer(): Promise<DataLayer<MainThreadClientConfig>>;
     isAuthenticated(): Promise<boolean>;
     updateConfig(config: Partial<AuthClientConfig<MainThreadClientConfig>>): Promise<void>;
-    trySignInSilently(): Promise<BasicUserInfo | boolean>;
+    trySignInSilently(additionalParams?: Record<string, string | boolean>): Promise<BasicUserInfo | boolean>;
     isSessionActive(): Promise<boolean>;
 }
 
@@ -97,5 +97,5 @@ export interface WebWorkerClientInterface {
     setHttpRequestFinishCallback(callback: () => void): void;
     refreshAccessToken(): Promise<BasicUserInfo>;
     updateConfig(config: Partial<AuthClientConfig<WebWorkerClientConfig>>): Promise<void>;
-    trySignInSilently(): Promise<BasicUserInfo | boolean>;
+    trySignInSilently(additionalParams?: Record<string, string | boolean>): Promise<BasicUserInfo | boolean>;
 }


### PR DESCRIPTION
## Purpose
Introduce the support to send additional params to the URL of `trySignInSilently`.

## Related Issues
- https://github.com/asgardeo/asgardeo-auth-spa-sdk/issues/164