### PR TITLE
Handle 401 failures gracefully

### DIFF
--- a/lib/src/client.ts
+++ b/lib/src/client.ts
@@ -54,6 +54,7 @@ const DefaultConfig: Partial<AuthClientConfig<Config>> = {
     checkSessionInterval: 3,
     clientHost: origin,
     enableOIDCSessionManagement: false,
+    periodicTokenRefresh: false,
     sessionRefreshInterval: 300,
     storage: Storage.SessionStorage
 };

--- a/lib/src/helpers/spa-helper.ts
+++ b/lib/src/helpers/spa-helper.ts
@@ -33,6 +33,13 @@ export class SPAHelper<T extends MainThreadClientConfig | WebWorkerClientConfig>
           MainThreadClientConfig | WebWorkerClientConfig
         >
       ): Promise<void> {
+        const shouldRefreshAutomatically: boolean = (await this._dataLayer.getConfigData())?.periodicTokenRefresh ?? 
+            false;
+        
+        if (!shouldRefreshAutomatically) {
+            return;
+        }
+
         const sessionData = await this._dataLayer.getSessionData();
         if (sessionData.refresh_token) {
             // Refresh 10 seconds before the expiry time

--- a/lib/src/models/client-config.ts
+++ b/lib/src/models/client-config.ts
@@ -31,6 +31,7 @@ export interface SPAConfig {
     sessionRefreshInterval?: number;
     resourceServerURLs?: string[];
     authParams?: Record<string, string>
+    periodicTokenRefresh?: boolean;
 }
 
 /**

--- a/lib/src/models/http-client.ts
+++ b/lib/src/models/http-client.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2020-2024, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -17,13 +17,23 @@
  */
 
 import { AxiosRequestConfig } from "axios";
-import { HttpError, HttpResponse } from ".";
+import { HttpClientInstance, HttpError, HttpResponse } from ".";
+import { SPACustomGrantConfig } from "..";
 
 export interface HttpClient {
     requestStartCallback: () => void;
     requestSuccessCallback: (response: HttpResponse) => void;
     requestErrorCallback: (error: HttpError) => void | Promise<void>;
     requestFinishCallback: () => void;
+}
+
+export interface HttpRequestInterface {
+    httpClient: HttpClientInstance,
+    requestConfig: HttpRequestConfig,
+    isHttpHandlerEnabled?: boolean,
+    httpErrorCallback?: (error: HttpError) => void | Promise<void>,
+    httpFinishCallback?: () => void,
+    enableRetrievingSignOutURLFromSession?: (config: SPACustomGrantConfig) => void
 }
 
 export interface HttpRequestConfig extends AxiosRequestConfig {

--- a/lib/src/utils/spa-utils.ts
+++ b/lib/src/utils/spa-utils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2020-2024, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -215,4 +215,19 @@ export class SPAUtils {
 
         await new Promise((resolve) => setTimeout(resolve, timeToWait * 1000));
     }
+
+    /**
+     * Waits for a condition before executing the rest of the code in non-blocking manner.
+     *
+     * @param condition {() => boolean} - Condition to be checked.
+     * @param timeout {number} - Time in miliseconds.
+     */
+    public static until = (
+        condition: () => boolean,
+        timeout: number = 500
+    ) => {
+        const poll = (done) => (condition() ? done() : setTimeout(() => poll(done), timeout));
+
+        return new Promise(poll);
+    };
 }


### PR DESCRIPTION
## Purpose
$subject

This will improve the token refresh logic to block the HTTP requests until the token is properly refreshed. 

Because of this improvement, there is no requirement to periodically refresh the token in the application as the token will be refreshed on demand. 

Therefore this will also introduce a config `periodicTokenRefresh` which will be set to `false` by default. If a user wishes to enable periodic refresh of the token, they can set it `true` and it will work as intended

## Goals
Resolves https://github.com/asgardeo/asgardeo-auth-spa-sdk/issues/166

## Related PRs
- https://github.com/asgardeo/asgardeo-auth-spa-sdk/pull/149
- https://github.com/asgardeo/asgardeo-auth-spa-sdk/pull/148
