### PR TITLE
Add config to prevent auto logout on token refresh errors

### DIFF
--- a/lib/src/models/client-config.ts
+++ b/lib/src/models/client-config.ts
@@ -32,6 +32,7 @@ export interface SPAConfig {
     resourceServerURLs?: string[];
     authParams?: Record<string, string>
     periodicTokenRefresh?: boolean;
+    autoLogoutOnTokenRefreshError?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Purpose

This will introduce a new config name `autoLogoutOnTokenRefreshError` which is set to `true` by default maintaining the default behaviour. When this is set to `false`, the SDK will not automatically signout the user upon encountering a token refresh error
