### PR TITLE
Allow defining storage type as a string

### DIFF
--- a/lib/src/constants/storage.ts
+++ b/lib/src/constants/storage.ts
@@ -32,6 +32,9 @@ export enum Storage {
      * Store the session information in the web worker.
      */
     WebWorker = "webWorker",
+    /**
+     * Store the session information in the browser memory.
+     */
     BrowserMemory = "browserMemory"
 }
 

--- a/lib/src/models/client-config.ts
+++ b/lib/src/models/client-config.ts
@@ -39,11 +39,26 @@ export interface SPAConfig {
  * SDK Client config parameters.
  */
 export interface MainThreadClientConfig extends SPAConfig {
-    storage?: Storage.SessionStorage | Storage.LocalStorage | Storage.BrowserMemory;
+    /**
+     * The storage type to be used for storing the session information.
+     */
+    storage?:
+        | Storage.SessionStorage
+        | Storage.LocalStorage
+        | Storage.BrowserMemory
+        | "sessionStorage"
+        | "localStorage"
+        | "browserMemory";
 }
 
 export interface WebWorkerClientConfig  extends SPAConfig {
-    storage: Storage.WebWorker;
+    /**
+     * The storage type to be used for storing the session information.
+     */
+    storage: Storage.WebWorker | "webWorker";
+    /**
+     * Specifies in seconds how long a request to the web worker should wait before being timed.
+     */
     requestTimeout?: number;
 }
 


### PR DESCRIPTION
## Purpose
This pull request introduces changes to the storage options for session information in the `lib/src/constants/storage.ts` and `lib/src/models/client-config.ts` files. The changes primarily involve adding new storage types and updating the interfaces to support these types.

### Storage Options Update:

* [`lib/src/constants/storage.ts`](diffhunk://#diff-7433a8519e435a2413599e6808598618b22d8562f003ce3b4d46e6bd8ece5d4fR35-R37): Added a new storage type `BrowserMemory` to the `Storage` enum.

### Client Configuration Update:

* [`lib/src/models/client-config.ts`](diffhunk://#diff-cada27b4076282827f5e19119587d9a9a4b6ee1dac3c1beddb0c71b3aeb40ed1L42-R61): Updated the `MainThreadClientConfig` interface to include the new `BrowserMemory` storage type and its string equivalent.
* [`lib/src/models/client-config.ts`](diffhunk://#diff-cada27b4076282827f5e19119587d9a9a4b6ee1dac3c1beddb0c71b3aeb40ed1L42-R61): Updated the `WebWorkerClientConfig` interface to allow the `WebWorker` storage type to be specified as a string and added a new `requestTimeout` parameter.

## Related Issues
- https://github.com/asgardeo/asgardeo-auth-react-sdk/issues/292

## Related PRs
N/A
