### PR TITLE
Allow TypeScript users to simply pass the `storage` option as a string literal

### DIFF
--- a/lib/src/client.ts
+++ b/lib/src/client.ts
@@ -235,7 +235,7 @@ export class AsgardeoSPAClient {
         authHelper?: typeof AuthenticationHelper,
         workerFile?: new () => Worker
     ): Promise<boolean> {
-        this._storage = config.storage ?? Storage.SessionStorage;
+        this._storage = config.storage as Storage ?? Storage.SessionStorage;
         this._initialized = false;
         this._startedInitialize = true;
 

--- a/lib/src/client.ts
+++ b/lib/src/client.ts
@@ -30,7 +30,7 @@ import {
 } from "@asgardeo/auth-js";
 import WorkerFile from "web-worker:./worker.ts";
 import { MainThreadClient, WebWorkerClient } from "./clients";
-import { Hooks, REFRESH_ACCESS_TOKEN_ERR0R, Storage } from "./constants";
+import { Hooks, REFRESH_ACCESS_TOKEN_ERR0R } from "./constants";
 import { AuthenticationHelper, SPAHelper } from "./helpers";
 import { HttpClientInstance } from "./http-client";
 import {
@@ -45,6 +45,7 @@ import {
     WebWorkerClientConfig,
     WebWorkerClientInterface
 } from "./models";
+import { Storage } from "./models/storage";
 import { SPAUtils } from "./utils";
 
 /**

--- a/lib/src/clients/main-thread-client.ts
+++ b/lib/src/clients/main-thread-client.ts
@@ -34,11 +34,7 @@ import {
     SessionData,
     Store
 } from "@asgardeo/auth-js";
-import {
-    SILENT_SIGN_IN_STATE,
-    Storage,
-    TOKEN_REQUEST_CONFIG_KEY
-} from "../constants";
+import { SILENT_SIGN_IN_STATE, TOKEN_REQUEST_CONFIG_KEY } from "../constants";
 import { AuthenticationHelper, SPAHelper, SessionManagementHelper } from "../helpers";
 import { HttpClient, HttpClientInstance } from "../http-client";
 import {
@@ -49,6 +45,7 @@ import {
     MainThreadClientInterface
 } from "../models";
 import { SPACustomGrantConfig } from "../models/request-custom-grant";
+import { Storage } from "../models/storage";
 import { LocalStore, MemoryStore, SessionStore } from "../stores";
 import { SPAUtils } from "../utils";
 import { SPACryptoUtils } from "../utils/crypto-utils";

--- a/lib/src/clients/main-thread-client.ts
+++ b/lib/src/clients/main-thread-client.ts
@@ -71,7 +71,7 @@ export const MainThreadClient = async (
         spaHelper: SPAHelper<MainThreadClientConfig>
     ) => AuthenticationHelper<MainThreadClientConfig>
 ): Promise<MainThreadClientInterface> => {
-    const _store: Store = initiateStore(config.storage);
+    const _store: Store = initiateStore(config.storage as Storage);
     const _cryptoUtils: SPACryptoUtils = new SPACryptoUtils();
     const _authenticationClient = new AsgardeoAuthClient<MainThreadClientConfig>();
     await _authenticationClient.initialize(config, _store, _cryptoUtils, instanceID);
@@ -82,7 +82,7 @@ export const MainThreadClient = async (
         async () => {
             return _authenticationClient.getSignOutURL();
         },
-        config.storage ?? Storage.SessionStorage,
+        config.storage as Storage ?? Storage.SessionStorage,
         (sessionState: string) => _dataLayer.setSessionDataParameter(SESSION_STATE as keyof SessionData, 
             sessionState ?? "")
     );

--- a/lib/src/clients/web-worker-client.ts
+++ b/lib/src/clients/web-worker-client.ts
@@ -61,7 +61,6 @@ import {
     SIGN_OUT,
     SILENT_SIGN_IN_STATE,
     START_AUTO_REFRESH_TOKEN,
-    Storage,
     UPDATE_CONFIG
 } from "../constants";
 import { AuthenticationHelper, SPAHelper, SessionManagementHelper } from "../helpers";
@@ -78,6 +77,7 @@ import {
     WebWorkerClientInterface
 } from "../models";
 import { SPACustomGrantConfig } from "../models/request-custom-grant";
+import { Storage } from "../models/storage";
 import { LocalStore, MemoryStore, SessionStore } from "../stores";
 import { SPAUtils } from "../utils";
 import { SPACryptoUtils } from "../utils/crypto-utils";

--- a/lib/src/clients/web-worker-client.ts
+++ b/lib/src/clients/web-worker-client.ts
@@ -115,7 +115,7 @@ export const WebWorkerClient = async (
     let _isHttpHandlerEnabled: boolean = true;
     let _getSignOutURLFromSessionStorage: boolean = false;
 
-    const _store: Store = initiateStore(config.storage);
+    const _store: Store = initiateStore(config.storage as Storage);
     const _cryptoUtils: SPACryptoUtils = new SPACryptoUtils();
     const _authenticationClient = new AsgardeoAuthClient<WebWorkerClientConfig>();
     await _authenticationClient.initialize(config, _store, _cryptoUtils, instanceID);
@@ -135,7 +135,7 @@ export const WebWorkerClient = async (
                 return SPAUtils.getSignOutURL(config.clientID, instanceID);
             }
         },
-        config.storage,
+        config.storage as Storage,
         (sessionState: string) => setSessionState(sessionState)
     );
 

--- a/lib/src/constants/storage.ts
+++ b/lib/src/constants/storage.ts
@@ -32,6 +32,9 @@ export enum Storage {
      * Store the session information in the web worker.
      */
     WebWorker = "webWorker",
+    /**
+     * Store the session information in the browser memory.
+     */
     BrowserMemory = "browserMemory"
 }
 

--- a/lib/src/constants/storage.ts
+++ b/lib/src/constants/storage.ts
@@ -16,26 +16,4 @@
  * under the License.
  */
 
-/**
- * Specifies where the session information should be stored.
- */
-export enum Storage {
-    /**
-     * Stores the session information in the local storage
-     */
-    LocalStorage = "localStorage",
-    /**
-     * Store the session information in the session storage.
-     */
-    SessionStorage = "sessionStorage",
-    /**
-     * Store the session information in the web worker.
-     */
-    WebWorker = "webWorker",
-    /**
-     * Store the session information in the browser memory.
-     */
-    BrowserMemory = "browserMemory"
-}
-
 export const TOKEN_REQUEST_CONFIG_KEY = "token_request_config";

--- a/lib/src/helpers/authentication-helper.ts
+++ b/lib/src/helpers/authentication-helper.ts
@@ -41,8 +41,7 @@ import {
     ERROR_DESCRIPTION,
     PROMPT_NONE_IFRAME,
     REFRESH_ACCESS_TOKEN_ERR0R,
-    RP_IFRAME,
-    Storage
+    RP_IFRAME
 } from "../constants";
 import {
     AuthorizationInfo,
@@ -57,6 +56,7 @@ import {
     WebWorkerClientConfig
 } from "../models";
 import { SPACustomGrantConfig } from "../models/request-custom-grant";
+import { Storage } from "../models/storage";
 import { SPAUtils } from "../utils";
 
 export class AuthenticationHelper<

--- a/lib/src/helpers/session-management-helper.ts
+++ b/lib/src/helpers/session-management-helper.ts
@@ -27,10 +27,10 @@ import {
     SET_SESSION_STATE_FROM_IFRAME,
     SILENT_SIGN_IN_STATE,
     STATE,
-    STATE_QUERY,
-    Storage
+    STATE_QUERY
 } from "../constants";
 import { AuthorizationInfo, Message, SessionManagementHelperInterface } from "../models";
+import { Storage } from "../models/storage";
 import { SPAUtils } from "../utils";
 
 export const SessionManagementHelper = (() => {

--- a/lib/src/models/client-config.ts
+++ b/lib/src/models/client-config.ts
@@ -39,11 +39,26 @@ export interface SPAConfig {
  * SDK Client config parameters.
  */
 export interface MainThreadClientConfig extends SPAConfig {
-    storage?: Storage.SessionStorage | Storage.LocalStorage | Storage.BrowserMemory;
+    /**
+     * The storage type to be used for storing the session information.
+     */
+    storage?:
+        | Storage.SessionStorage
+        | Storage.LocalStorage
+        | Storage.BrowserMemory
+        | "sessionStorage"
+        | "localStorage"
+        | "browserMemory";
 }
 
 export interface WebWorkerClientConfig  extends SPAConfig {
-    storage: Storage.WebWorker;
+    /**
+     * The storage type to be used for storing the session information.
+     */
+    storage: Storage.WebWorker | "webWorker";
+    /**
+     * Specifies in seconds how long a request to the web worker should wait before being timed.
+     */
     requestTimeout?: number;
 }
 

--- a/lib/src/models/client-config.ts
+++ b/lib/src/models/client-config.ts
@@ -17,7 +17,7 @@
 */
 
 import { AuthClientConfig } from "@asgardeo/auth-js";
-import { Storage } from "../constants";
+import { Storage } from "../models/storage";
 
 
 export interface SPAConfig {

--- a/lib/src/models/storage.ts
+++ b/lib/src/models/storage.ts
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Enum for the different storage types.
+ */
+export enum Storage {
+  /**
+   * Stores the session information in the local storage
+   */
+  LocalStorage = "localStorage",
+  /**
+   * Store the session information in the session storage.
+   */
+  SessionStorage = "sessionStorage",
+  /**
+   * Store the session information in the web worker.
+   */
+  WebWorker = "webWorker",
+  /**
+   * Store the session information in the browser memory.
+   */
+  BrowserMemory = "browserMemory"
+}


### PR DESCRIPTION
## Purpose

ATM, when using TypeScript, we can't pass the `storage` option as strings. We need to use the `Storage` enum or cast the string. This is not good DX.

## Approach

This pull request includes changes to refactor the `Storage` enum by moving it from `constants` to `models/storage`, and updates the codebase to use the new location. Additionally, it ensures type safety by using type assertions for the `storage` configuration.

### Refactoring and Codebase Updates:

* [`lib/src/constants/storage.ts`](diffhunk://#diff-7433a8519e435a2413599e6808598618b22d8562f003ce3b4d46e6bd8ece5d4fL19-L37): Removed the `Storage` enum from the `constants` file.
* [`lib/src/models/storage.ts`](diffhunk://#diff-9eda98f45c8d8f31c1d7f5e50414a38c7ca8e4ad8b447f6d37f0ac9713206ad1R1-R39): Added the `Storage` enum to the `models/storage` file with updated documentation.

### Import Statement Adjustments:

* [`lib/src/client.ts`](diffhunk://#diff-2098423283b932abfdf6e63d8b75e03eee0c5059a14d65636608f3f2dc29f167L33-R33): Updated import statements to reflect the new location of the `Storage` enum and used type assertions for `config.storage`. [[1]](diffhunk://#diff-2098423283b932abfdf6e63d8b75e03eee0c5059a14d65636608f3f2dc29f167L33-R33) [[2]](diffhunk://#diff-2098423283b932abfdf6e63d8b75e03eee0c5059a14d65636608f3f2dc29f167R48) [[3]](diffhunk://#diff-2098423283b932abfdf6e63d8b75e03eee0c5059a14d65636608f3f2dc29f167L237-R238)
* [`lib/src/clients/main-thread-client.ts`](diffhunk://#diff-afbc43b6fe4279b793031f30be57a71ebb14ef04b2633a1937e11f001febaebfL37-R37): Updated import statements and used type assertions for `config.storage`. [[1]](diffhunk://#diff-afbc43b6fe4279b793031f30be57a71ebb14ef04b2633a1937e11f001febaebfL37-R37) [[2]](diffhunk://#diff-afbc43b6fe4279b793031f30be57a71ebb14ef04b2633a1937e11f001febaebfR48) [[3]](diffhunk://#diff-afbc43b6fe4279b793031f30be57a71ebb14ef04b2633a1937e11f001febaebfL77-R74) [[4]](diffhunk://#diff-afbc43b6fe4279b793031f30be57a71ebb14ef04b2633a1937e11f001febaebfL88-R85)
* [`lib/src/clients/web-worker-client.ts`](diffhunk://#diff-9ea84797a1857c92f75153d76c4d51763c3410a09dacf043b5dd43ad3f12788dL64): Updated import statements and used type assertions for `config.storage`. [[1]](diffhunk://#diff-9ea84797a1857c92f75153d76c4d51763c3410a09dacf043b5dd43ad3f12788dL64) [[2]](diffhunk://#diff-9ea84797a1857c92f75153d76c4d51763c3410a09dacf043b5dd43ad3f12788dR80) [[3]](diffhunk://#diff-9ea84797a1857c92f75153d76c4d51763c3410a09dacf043b5dd43ad3f12788dL118-R118) [[4]](diffhunk://#diff-9ea84797a1857c92f75153d76c4d51763c3410a09dacf043b5dd43ad3f12788dL138-R138)
* [`lib/src/helpers/authentication-helper.ts`](diffhunk://#diff-84bd701c1d02aea7f47aa817edb57d54213b0cb51a702570b3c4dcb044599a48L44-R44): Updated import statements to reflect the new location of the `Storage` enum. [[1]](diffhunk://#diff-84bd701c1d02aea7f47aa817edb57d54213b0cb51a702570b3c4dcb044599a48L44-R44) [[2]](diffhunk://#diff-84bd701c1d02aea7f47aa817edb57d54213b0cb51a702570b3c4dcb044599a48R59)
* [`lib/src/helpers/session-management-helper.ts`](diffhunk://#diff-7d0c788eaa02d3dc0fdf12480d7c9ddc540d42d067ab739246a0bedbb05dcc02L30-R33): Updated import statements to reflect the new location of the `Storage` enum.

### Configuration Interface Updates:

* [`lib/src/models/client-config.ts`](diffhunk://#diff-cada27b4076282827f5e19119587d9a9a4b6ee1dac3c1beddb0c71b3aeb40ed1L20-R20): Updated the `SPAConfig` interface to include the new `storage` type options and added documentation. [[1]](diffhunk://#diff-cada27b4076282827f5e19119587d9a9a4b6ee1dac3c1beddb0c71b3aeb40ed1L20-R20) [[2]](diffhunk://#diff-cada27b4076282827f5e19119587d9a9a4b6ee1dac3c1beddb0c71b3aeb40ed1L42-R61)

## Related Issues
- https://github.com/asgardeo/asgardeo-auth-react-sdk/issues/292