### PR TITLE
fix: improve error serialization in generateFailureMessage to handle axios errors correctly

### DIFF
--- a/lib/src/utils/message-utils.ts
+++ b/lib/src/utils/message-utils.ts
@@ -40,7 +40,14 @@ export class MessageUtils {
     }
 
     /**
-     * JSON stringifies the passed object.
+     *
+     * Explicitly constructs a serializable error shape instead of relying on
+     * JSON.stringify(error) directly. This is necessary because axios 1.x defines
+     * toJSON() on the AxiosError prototype which deliberately excludes `response`
+     * (to avoid leaking sensitive data). Since toJSON() is on the prototype and not
+     * the instance, `delete error.toJSON` is a no-op, and JSON.stringify ends up
+     * calling the prototype's toJSON — stripping response.data (and server-side
+     * error codes like BPM-60006) from the postMessage payload.
      *
      * @param {any} error The error object.
      *
@@ -48,12 +55,26 @@ export class MessageUtils {
      */
     // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
     public static generateFailureMessage(error?: any): ResponseMessage<string> {
-        if (error?.toJSON) {
-            delete error.toJSON;
-        }
+        const serializable: any = error ? {
+            code: error?.code,
+            config: error?.config,
+            isAxiosError: error?.isAxiosError,
+            message: error?.message,
+            name: error?.name,
+            request: error?.request,
+            response: error?.response ? {
+                config: error.response.config,
+                data: error.response.data,
+                headers: error.response.headers,
+                request: error.response.request,
+                status: error.response.status,
+                statusText: error.response.statusText
+            } : undefined,
+            status: error?.status ?? error?.response?.status ?? null
+        } : "";
 
         return {
-            error: JSON.stringify(error ?? ""),
+            error: JSON.stringify(serializable),
             success: false
         };
     }


### PR DESCRIPTION
### Problem
>After upgrading axios from 0.x to 1.x, API errors that occurred inside the Web Worker arrived on the main thread with no response property.

### Root Cause
>axios 1.x added toJSON() on AxiosError.prototype which deliberately excludes response (to prevent sensitive response bodies from appearing in error logs). generateFailureMessage called JSON.stringify(error) which automatically invokes toJSON(). The existing delete error.toJSON was a no-op since toJSON lives on the prototype, not the instance in the new axios versions.

>generateFailureMessage is the single point through which every error crosses the Web Worker boundary. Fixing it fixes all callers.

### Fix
>Replace blind JSON.stringify(error) with an explicit plain-object serialization that bypasses toJSON() entirely and reconstructs the full error shape the main thread expects. This restores the exact error shape that existed with axios 0.x, so all SDK consumers work again without any changes on their side.
