### PR TITLE
fix: resolve Safari SSE streaming failure in httpStreamRequest due to DataCloneError

### DIFF
--- a/lib/src/clients/web-worker-client.ts
+++ b/lib/src/clients/web-worker-client.ts
@@ -187,13 +187,16 @@ export const WebWorkerClient = async (
      * Unlike `communicate`, this does NOT JSON.parse the response data,
      * because the response contains a transferred ReadableStream.
      */
-    const communicateStream = (message: Message<HttpRequestConfig>): Promise<ReadableStream> => {
+    const communicateStream = (message: Message<HttpRequestConfig>): Promise<ReadableStream<Uint8Array>> => {
         const channel = new MessageChannel();
 
         worker.postMessage(message, [channel.port2]);
 
         return new Promise((resolve, reject) => {
             const timer = setTimeout(() => {
+                channel.port1.onmessage = null;
+                channel.port1.close();
+                channel.port2.close();
                 reject(
                     new AsgardeoAuthException(
                         "SPA-WEB_WORKER_CLIENT-COMS-TO01",
@@ -205,19 +208,58 @@ export const WebWorkerClient = async (
                 );
             }, _requestTimeout);
 
-            return (channel.port1.onmessage = ({ data }: { data: any; }) => {
-                clearTimeout(timer);
+            let streamStarted: boolean = false;
+            let streamController: ReadableStreamDefaultController<Uint8Array> | null = null;
+
+            // Tears down the channel and cancels the worker-side reader when the
+            // consumer cancels the stream (e.g. request aborted mid-stream).
+            const cancelStream = (): void => {
+                channel.port1.onmessage = null;
                 channel.port1.close();
                 channel.port2.close();
+            };
 
-                if (data?.success) {
-                    // Raw stream message shape: { success: true, data: ReadableStream }
-                    // (posted directly from worker-receiver, NOT via generateSuccessMessage)
-                    resolve(data?.data as ReadableStream);
-                } else {
-                    reject(data.error ? JSON.parse(data.error) : null);
+            channel.port1.onmessage = ({ data }: { data: any }) => {
+                // Worker reported a failure.
+                if (!data?.success) {
+                    clearTimeout(timer);
+                    cancelStream();
+                    if (streamController) {
+                        streamController.error(
+                            data?.error ? JSON.parse(data.error) : new Error("Stream failed")
+                        );
+                    } else {
+                        reject(data?.error ? JSON.parse(data.error) : null);
+                    }
+
+                    return;
                 }
-            });
+
+                // First successful message — create the ReadableStream and resolve the promise.
+                // Subsequent messages will push chunks into the controller.
+                if (!streamStarted) {
+                    clearTimeout(timer);
+                    streamStarted = true;
+                    const stream: ReadableStream<Uint8Array> = new ReadableStream<Uint8Array>({
+                        cancel(): void {
+                            cancelStream();
+                        },
+                        start(controller: ReadableStreamDefaultController<Uint8Array>): void {
+                            streamController = controller;
+                        }
+                    });
+
+                    resolve(stream);
+                }
+
+                if (data?.done) {
+                    // Worker signalled end of stream.
+                    streamController?.close();
+                    cancelStream();
+                } else if (data?.chunk !== undefined) {
+                    streamController?.enqueue(data.chunk as Uint8Array);
+                }
+            };
         });
     };
 

--- a/lib/src/worker/worker-receiver.ts
+++ b/lib/src/worker/worker-receiver.ts
@@ -160,16 +160,32 @@ export const workerReceiver = (
                         const stream = (response as any)?.data;
 
                         if (stream instanceof ReadableStream) {
-                            // Post raw message — do NOT use generateSuccessMessage here.
-                            // generateSuccessMessage calls JSON.stringify which turns a
-                            // ReadableStream into {} and the stream reference is lost.
-                            port.postMessage(
-                                {
-                                    data: stream,
-                                    success: true
-                                },
-                                [stream as any]
-                            );
+                            // Safari cannot transfer a ReadableStream via postMessage
+                            // (throws DataCloneError). Pipe chunks back individually so
+                            // the main thread can reconstruct the stream from messages.
+                            const reader: ReadableStreamDefaultReader<Uint8Array> = stream.getReader();
+
+                            const pump = (): void => {
+                                reader
+                                    .read()
+                                    .then(({ done, value }: { done: boolean; value?: Uint8Array }) => {
+                                        if (done) {
+                                            port.postMessage({ done: true, success: true });
+                                        } else {
+                                            // Transfer the underlying ArrayBuffer to avoid copying.
+                                            port.postMessage(
+                                                { chunk: value, success: true },
+                                                value?.buffer ? [ value.buffer ] : []
+                                            );
+                                            pump();
+                                        }
+                                    })
+                                    .catch((err: unknown) => {
+                                        port.postMessage(MessageUtils.generateFailureMessage(err));
+                                    });
+                            };
+
+                            pump();
                         } else {
                             port.postMessage(MessageUtils.generateSuccessMessage(response));
                         }


### PR DESCRIPTION
### Problem
httpStreamRequest fails silently in Safari when used to consume Server-Sent Events (SSE) streaming responses. The request reaches the backend and returns HTTP 200, but no data is delivered to the caller and an error is shown to the user.

### Root cause
After the web worker successfully makes the fetch request and receives the ReadableStream from response.body, it attempts to transfer the stream to the main thread via:

`port.postMessage({ data: stream, success: true }, [stream]);`

Safari's web worker throws DataCloneError: The object can not be cloned (code 25). 
Safari does not support ReadableStream as a transferable object in postMessage. The worker's catch handler then sends a failure message to the main thread, which rejects the Promise and surfaces as a generic error in the UI.

This does not affect Chrome, which supports transferable ReadableStream.

### Fix
Instead of transferring the ReadableStream object, the worker now reads the stream chunk by chunk and sends each Uint8Array chunk back to the main thread as a separate postMessage. The main thread reconstructs a ReadableStream from these incoming chunk messages.

The underlying ArrayBuffer is transferred (not copied) on each chunk postMessage, so there is no performance regression.

**Changes**
`src/worker/worker-receiver.ts` - pipe stream chunks via postMessage instead of attempting to transfer the ReadableStream object
src/clients/web-worker-client.ts - reconstruct a ReadableStream from incoming chunk messages instead of expecting a single stream transfer